### PR TITLE
Fix/change cut off edit text button

### DIFF
--- a/zeapp/app/src/main/java/de/berlindroid/zeapp/MainActivity.kt
+++ b/zeapp/app/src/main/java/de/berlindroid/zeapp/MainActivity.kt
@@ -377,7 +377,7 @@ private fun PagePreview(
                     item {
                         ToolButton(
                             imageVector = Icons.Filled.Edit,
-                            text = "Change",
+                            text = "Edit",
                             onClick = customizeThisPage,
                         )
                     }

--- a/zeapp/app/src/main/java/de/berlindroid/zeapp/ui/ToolButton.kt
+++ b/zeapp/app/src/main/java/de/berlindroid/zeapp/ui/ToolButton.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -45,7 +46,8 @@ fun ToolButton(
             )
             Text(
                 text = text,
-                fontSize = 12.sp
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurface
             )
         }
     }
@@ -72,13 +74,14 @@ fun ToolButton(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Icon(
-                tint = Color.Unspecified,
+                tint = MaterialTheme.colorScheme.onSurface,
                 imageVector = imageVector,
                 contentDescription = null,
             )
             Text(
                 text = text,
-                fontSize = 12.sp
+                fontSize = 12.sp,
+                color = MaterialTheme.colorScheme.onSurface
             )
         }
     }

--- a/zeapp/app/src/main/java/de/berlindroid/zeapp/ui/ToolButton.kt
+++ b/zeapp/app/src/main/java/de/berlindroid/zeapp/ui/ToolButton.kt
@@ -6,8 +6,8 @@ import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Send
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -29,7 +29,7 @@ fun ToolButton(
     text: String = "Decline",
     onClick: () -> Unit = {}
 ) {
-    IconButton(
+    TextButton(
         onClick = onClick,
         modifier = Modifier.wrapContentHeight(),
     ) {
@@ -62,7 +62,7 @@ fun ToolButton(
     text: String = "Send",
     onClick: () -> Unit = {}
 ) {
-    IconButton(
+    TextButton(
         onClick = onClick,
         modifier = Modifier.wrapContentHeight(),
     ) {


### PR DESCRIPTION
Fixes a visual bug on the pages list and in the edit page dialog.
Previously, the used `IconButton` in `ToolButton` did cut off long or big text (text could be big due to accessibility settings).

## Fix
Remove the usage of `IconButton` which is usually only used without labels. Use a `TextButton` instead.