### PR TITLE
Change dependency declaration to Gradle version catalog

### DIFF
--- a/zeapp/app/build.gradle
+++ b/zeapp/app/build.gradle
@@ -1,6 +1,6 @@
 plugins {
-    id 'com.android.application'
-    id 'org.jetbrains.kotlin.android'
+    alias libs.plugins.android.application
+    alias libs.plugins.kotlin.android
 }
 
 android {
@@ -48,7 +48,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion '1.4.8'
+        kotlinCompilerExtensionVersion libs.versions.androidx.compose.compiler.get()
     }
 
     packagingOptions {
@@ -59,20 +59,19 @@ android {
 }
 
 dependencies {
-    implementation platform('androidx.compose:compose-bom:2022.10.00')
+    implementation platform(libs.androidx.compose.bom)
 
-    implementation 'androidx.core:core-ktx:1.10.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.6.1'
-    implementation 'androidx.activity:activity-compose:1.7.1'
-    implementation 'androidx.compose.ui:ui'
-    implementation 'androidx.compose.ui:ui-graphics'
-    implementation 'androidx.compose.ui:ui-tooling-preview'
-    implementation 'androidx.compose.material3:material3'
-    implementation 'com.squareup.retrofit2:retrofit:2.9.0'
-    implementation 'com.squareup.retrofit2:converter-gson:2.9.0'
+    implementation libs.androidx.core.ktx
+    implementation libs.androidx.lifecycle.runtime.ktx
+    implementation libs.androidx.activity.compose
+    implementation libs.androidx.compose.ui.ui
+    implementation libs.androidx.compose.ui.graphics
+    implementation libs.androidx.compose.ui.toolingpreview
+    implementation libs.androidx.compose.material3
+    implementation libs.retrofit2.retrofit
+    implementation libs.retrofit2.converter.gson
+    implementation libs.mik3y.usb.serial.android
 
-    implementation 'com.github.mik3y:usb-serial-for-android:3.5.1'
-
-    debugImplementation 'androidx.compose.ui:ui-tooling'
-    debugImplementation 'androidx.compose.ui:ui-test-manifest'
+    debugImplementation libs.androidx.compose.ui.tooling
+    debugImplementation libs.androidx.compose.ui.test.manifest
 }

--- a/zeapp/build.gradle
+++ b/zeapp/build.gradle
@@ -1,6 +1,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
-    id 'com.android.application' version '8.0.2' apply false
-    id 'com.android.library' version '8.0.2' apply false
-    id 'org.jetbrains.kotlin.android' version '1.8.22' apply false
+    alias libs.plugins.android.application apply false
+    alias libs.plugins.android.library apply false
+    alias libs.plugins.kotlin.android apply false
 }

--- a/zeapp/gradle/libs.versions.toml
+++ b/zeapp/gradle/libs.versions.toml
@@ -1,0 +1,30 @@
+[versions]
+kotlin = "1.8.22"
+android-gradle-plugin = "8.0.2"
+androidx-compose-compiler = "1.4.8"
+androidx-compose-bom = "2022.10.00"
+androidx-core = "1.10.1"
+androidx-lifecycle = "2.6.1"
+androidx-activity = "1.7.1"
+retrofit = "2.9.0"
+mik3y-usb-serial = "3.5.1"
+
+[libraries]
+androidx-compose-bom = { module = "androidx.compose:compose-bom", version.ref = "androidx-compose-bom" }
+androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "androidx-core" }
+androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtime-ktx", version.ref = "androidx-lifecycle" }
+androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
+androidx-compose-ui-ui = { module = "androidx.compose.ui:ui" }
+androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-ui-toolingpreview = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
+androidx-compose-material3 = { module = "androidx.compose.material3:material3" }
+retrofit2-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
+retrofit2-converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
+mik3y-usb-serial-android = { module = "com.github.mik3y:usb-serial-for-android", version.ref = "mik3y-usb-serial" }
+
+[plugins]
+android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
+android-library = { id = "com.android.library", version.ref = "android-gradle-plugin"  }
+kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin"  }


### PR DESCRIPTION
This changes the dependency declaration of the project to use a Gradle version catalog. See: [Central declaration of dependencies](https://docs.gradle.org/current/userguide/platforms.html#sub:central-declaration-of-dependencies)