### PR TITLE
Add tests for the zipit function

### DIFF
--- a/zeapp/app/build.gradle
+++ b/zeapp/app/build.gradle
@@ -76,6 +76,9 @@ dependencies {
     implementation 'com.google.zxing:core:3.5.0'
     debugImplementation libs.androidx.compose.ui.tooling
     debugImplementation libs.androidx.compose.ui.test.manifest
+
+    testImplementation(libs.test.assertk)
+    testImplementation(libs.test.junit)
 }
 
 // Ktlint

--- a/zeapp/app/src/test/java/de/berlindroid/zeapp/hardware/ZipitTest.kt
+++ b/zeapp/app/src/test/java/de/berlindroid/zeapp/hardware/ZipitTest.kt
@@ -1,0 +1,43 @@
+package de.berlindroid.zeapp.hardware
+
+import assertk.assertThat
+import assertk.assertions.isEqualTo
+import java.util.zip.Inflater
+import org.junit.Test
+
+class ZipitTest {
+
+    @Test
+    fun zipString() {
+        val input = "Hello, world!"
+        val expected = byteArrayOf(120, -38, -13, 72, -51, -55, -55, -41, 81, 40, -49, 47, -54, 73, 81, 4, 0, 32, 94, 4, -118)
+        val actual = input.toByteArray().zipit()
+        assertThat(actual).isEqualTo(expected)
+    }
+
+    @Test
+    fun zipUnzip() {
+        val input = "Hello, world!"
+        val zipped = input.toByteArray().zipit()
+        val unzipped = String(zipped.unzipByteArray())
+
+        assertThat(unzipped).isEqualTo(input)
+    }
+
+    private fun ByteArray.unzipByteArray(): ByteArray {
+        val inflater = Inflater()
+        inflater.setInput(this)
+
+        val buffer = ByteArray(1024)
+        val output = mutableListOf<Byte>()
+
+        while (!inflater.finished()) {
+            val count = inflater.inflate(buffer)
+            output.addAll(buffer.take(count))
+        }
+
+        inflater.end()
+
+        return output.toByteArray()
+    }
+}

--- a/zeapp/gradle/libs.versions.toml
+++ b/zeapp/gradle/libs.versions.toml
@@ -25,6 +25,9 @@ retrofit2-retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref =
 retrofit2-converter-gson = { module = "com.squareup.retrofit2:converter-gson", version.ref = "retrofit" }
 mik3y-usb-serial-android = { module = "com.github.mik3y:usb-serial-for-android", version.ref = "mik3y-usb-serial" }
 
+test-assertk = "com.willowtreeapps.assertk:assertk-jvm:0.25"
+test-junit = "junit:junit:4.13.2"
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "android-gradle-plugin" }
 android-library = { id = "com.android.library", version.ref = "android-gradle-plugin"  }


### PR DESCRIPTION
This PR adds 2 tests for the `zipit` function.

- The first test, `zipString`, verifies the compression of a string by comparing the expected compressed byte array with the actual result obtained from calling `zipit` function. It uses a sample input string and its corresponding expected compressed byte array.
- The second test, `zipUnzip`, validates the end-to-end functionality of the `zipit` and `unzipit` operations. It uses the `unzipit` function defined in the test to decompress a sample compressed byte array and checks if the resulting string matches the original input.