### PR TITLE
remove mutable state wrapper and neitherNullNorEmpty extension

### DIFF
--- a/zeapp/app/src/main/java/de/berlindroid/zeapp/zeservices/ZePreferencesService.kt
+++ b/zeapp/app/src/main/java/de/berlindroid/zeapp/zeservices/ZePreferencesService.kt
@@ -29,8 +29,8 @@ class ZePreferencesService @Inject constructor(
         )
     }
 
-    fun getOpenApiKey(): String? {
-        return sharedPreferences.getString(OPEN_API_PREFERENCES_KEY, "")
+    fun getOpenApiKey(): String {
+        return sharedPreferences.getString(OPEN_API_PREFERENCES_KEY, null).orEmpty()
     }
 
     fun isSlotConfigured(slot: ZeSlot): Boolean {

--- a/zeapp/app/src/main/java/de/berlindroid/zeapp/zevm/ZeBadgeViewModel.kt
+++ b/zeapp/app/src/main/java/de/berlindroid/zeapp/zevm/ZeBadgeViewModel.kt
@@ -85,11 +85,10 @@ class ZeBadgeViewModel @Inject constructor(
 
     // which page should be displayed in the simulator?
     val currentSimulatorSlot = mutableStateOf<ZeSlot>(ZeSlot.Name)
-    val openApiKey = mutableStateOf(
-        OPENAI_API_KEY.ifBlank {
-            preferencesService.getOpenApiKey()
-        }
-    )
+    private val openApiKey = OPENAI_API_KEY.ifBlank {
+        preferencesService.getOpenApiKey()
+    }
+
 
     val slots = mutableStateOf(
         mapOf(
@@ -128,7 +127,12 @@ class ZeBadgeViewModel @Inject constructor(
                 )
             }
         } else {
-            _toastEvent.tryEmit(ZeToastEvent("Please give binary image for page '${slot.name}'.", ZeToastEvent.Duration.LONG))
+            _toastEvent.tryEmit(
+                ZeToastEvent(
+                    "Please give binary image for page '${slot.name}'.",
+                    ZeToastEvent.Duration.LONG
+                )
+            )
         }
     }
 
@@ -209,7 +213,7 @@ class ZeBadgeViewModel @Inject constructor(
                     ZeConfiguration.Camera(R.drawable.soon.toBitmap().ditherFloydSteinberg())
                 ).apply {
                     // Surprise mechanic: If token is set, show open ai item
-                    if (openApiKey.value.isNeitherNullNorBlank()) {
+                    if (openApiKey.isNotBlank()) {
                         add(
                             2,
                             ZeConfiguration
@@ -368,5 +372,3 @@ private fun <K, V> Map<K, V>.copy(vararg entries: Pair<K, V>): Map<K, V> {
 
     return result.toMap()
 }
-
-private fun String?.isNeitherNullNorBlank(): Boolean = !this.isNullOrBlank()


### PR DESCRIPTION
- This pr removes the mutableStateOf call since the value of the state is never updated and is read only.
- Since we already have a method to retrieve the api key we can ensure that it's not null and remove the extension function that checked whether the string was not null and not empty.