### PR TITLE
Make list item actions at the bottom accessible

### DIFF
--- a/zeapp/app/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
+++ b/zeapp/app/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
@@ -48,6 +48,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import dagger.hilt.android.AndroidEntryPoint
 import de.berlindroid.zeapp.zemodels.ZeConfiguration
@@ -271,8 +272,10 @@ private fun ZePages(
             ZeLazyColumn(
                 state = lazyListState,
                 contentPadding = PaddingValues(
-                    horizontal = Dimen.One,
-                    vertical = Dimen.Half
+                    start = Dimen.One,
+                    end = Dimen.One,
+                    top = Dimen.Half,
+                    bottom = 140.dp
                 )
             ) {
                 items(


### PR DESCRIPTION
The edit action of the bottom list item was covered by the FAB, which made it barely usable.