### PR TITLE
Fix Compose previews

### DIFF
--- a/zeapp/app/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
+++ b/zeapp/app/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
@@ -424,7 +424,7 @@ private fun SelectedEditor(
             }
 
             is ZeConfiguration.BarCode -> BarCodeEditorDialog(
-                activity,
+                LocalActivity.current,
                 config,
                 dismissed = { vm.slotConfigured(editor.slot, null) }
             ) { newConfig ->

--- a/zeapp/app/src/main/res/values-de-rDE/strings.xml
+++ b/zeapp/app/src/main/res/values-de-rDE/strings.xml
@@ -14,8 +14,11 @@
     <string name="enter_prompt">Befehl hier eingeben</string>
     <string name="could_not_generate_image">Konnte Bild nicht generieren</string>
 
-    <string name="image_needed">Binär Bild benötigt. Drücker einen der Knöpfe unter dem Bild.</string>
+    <string name="image_needed">Binär Bild benötigt. Drücke einen der Knöpfe unter dem Bild.</string>
     <string name="add_qr_url">Füge deine QR URL hinzu</string>
     <string name="qr_code_title">QR Code Title</string>
     <string name="url">URL</string>
+
+    <string name="add_barcode_url">Barcode URL hinzufügen</string>
+    <string name="bar_code_title">Barcode Titel</string>
 </resources>

--- a/zeapp/gradle/libs.versions.toml
+++ b/zeapp/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "dagger-hil
 [versions]
 
 kotlin = "1.8.22"
-android-gradle-plugin = "8.1.0-rc01"
+android-gradle-plugin = "8.0.2"
 androidx-compose-compiler = "1.4.8"
 androidx-compose-bom = "2023.06.01"
 androidx-core = "1.10.1"

--- a/zeapp/gradle/libs.versions.toml
+++ b/zeapp/gradle/libs.versions.toml
@@ -13,7 +13,7 @@ dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "dagger-hil
 [versions]
 
 kotlin = "1.8.22"
-android-gradle-plugin = "8.0.2"
+android-gradle-plugin = "8.1.0-rc01"
 androidx-compose-compiler = "1.4.8"
 androidx-compose-bom = "2023.06.01"
 androidx-core = "1.10.1"
@@ -36,7 +36,7 @@ androidx-lifecycle-runtime-ktx = { module = "androidx.lifecycle:lifecycle-runtim
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-compose-ui-ui = { module = "androidx.compose.ui:ui" }
 androidx-compose-ui-graphics = { module = "androidx.compose.ui:ui-graphics" }
-androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling-preview" }
+androidx-compose-ui-tooling = { module = "androidx.compose.ui:ui-tooling" }
 androidx-compose-ui-toolingpreview = { module = "androidx.compose.ui:ui-tooling-preview" }
 androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest" }
 androidx-compose-material3 = { module = "androidx.compose.material3:material3" }


### PR DESCRIPTION
Before compose previews did not work.

Now:
<img width="360" alt="image" src="https://github.com/gdg-berlin-android/ZeBadge/assets/400322/712d35ed-4a6f-486e-b3bb-e0b3bbad26a9">

# 🎉 