### PR TITLE
Fetch entire history for builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
     steps:
       - name: "Checkout Repo"
         uses: actions/checkout@v3
+        fetch-depth: 0
       - name: "Setup Java 17"
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
Fixes the list of contributors on the About screen which needs the entire Git history to be generated