### PR TITLE
fix: show soft keyboard also when ZeBadge is connected

### DIFF
--- a/zeapp/app/src/main/AndroidManifest.xml
+++ b/zeapp/app/src/main/AndroidManifest.xml
@@ -19,6 +19,7 @@
             android:name=".ZeMainActivity"
             android:exported="true"
             android:theme="@style/Theme.ZeBadgeApp"
+            android:windowSoftInputMode="stateAlwaysVisible|adjustResize"
             android:configChanges="orientation|screenLayout|screenSize|smallestScreenSize|keyboard|keyboardHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
This PR fixes the issue, that the soft keyboard is not showing when focusing an input field while ZeBadge is connected to the device. This happens because Android treats ZeBadge like a physical keyboard.

