### PR TITLE
Ensure weather starts with the current date by default rather than hardcoded

### DIFF
--- a/zeapp/app/src/main/java/de/berlindroid/zeapp/zevm/ZeBadgeViewModel.kt
+++ b/zeapp/app/src/main/java/de/berlindroid/zeapp/zevm/ZeBadgeViewModel.kt
@@ -31,6 +31,8 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 private const val MESSAGE_DISPLAY_DURATION = 3_000L
@@ -355,7 +357,7 @@ class ZeBadgeViewModel @Inject constructor(
             )
 
             ZeSlot.Weather -> ZeConfiguration.Weather(
-                "2023-07-06",
+                LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE),
                 "22C",
                 R.drawable.soon.toBitmap(),
             )


### PR DESCRIPTION
Ensures that the API replies with a valid value without switching current date (otherwise, by default, you will see error values, since weather predictions aren't available for dates in the past)