### PR TITLE
Suppress unused compose preview method

### DIFF
--- a/zeapp/app/src/main/java/de/berlindroid/zeapp/zeui/zepages/ZeNamePage.kt
+++ b/zeapp/app/src/main/java/de/berlindroid/zeapp/zeui/zepages/ZeNamePage.kt
@@ -94,6 +94,7 @@ fun NamePage(
  */
 @Composable
 @Preview
+@Suppress("UnusedPrivateMember")
 private fun NamePagePreview2(
     name: String = "Your Name Here is very long",
     contact: String = "Contact Me Here is very long long",


### PR DESCRIPTION
Suppressing the detekt find for now till more places need it.

If more previews are created, we need to think about a detekt config change.