### PR TITLE
Improving Portuguese translations + Compose string use

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
@@ -369,13 +369,13 @@ private fun ZeDrawerContent(
                 NavDrawerItem(
                     onClick = onSaveAllClick,
                     painter = painterResource(id = R.drawable.save_all),
-                    text = "Save all pages to badge",
+                    text = stringResource(id = R.string.ze_navdrawer_save_all_pages),
                 )
             }
 
             item {
                 NavDrawerItem(
-                    text = "Update config on badge",
+                    text = stringResource(id = R.string.ze_navdrawer_update_config),
                     vector = Icons.Default.ThumbUp,
                     onClick = onUpdateConfig,
                 )
@@ -384,7 +384,7 @@ private fun ZeDrawerContent(
             item {
                 NavDrawerItem(
                     painter = painterResource(id = R.drawable.ic_random),
-                    text = "Send random page to badge",
+                    text = stringResource(id = R.string.ze_navdrawer_send_random_page),
                     onClick = onGetStoredPages,
                 )
             }
@@ -402,7 +402,7 @@ private fun ZeDrawerContent(
 
             item {
                 NavDrawerItem(
-                    text = "Open release page",
+                    text = stringResource(id = R.string.ze_navdrawer_open_release_page),
                     painter = painterResource(id = R.drawable.ic_update),
                     onClick = onGotoReleaseClick,
                 )

--- a/zeapp/android/src/main/res/values-pt-rBR/strings.xml
+++ b/zeapp/android/src/main/res/values-pt-rBR/strings.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-
-    <string name="app_name">Ze Androft</string>
-    <string name="repo_url" translatable="false">https://github.com/gdg-berlin-android</string>
-
     <string name="black_and_white">P/B</string>
     <string name="reset">Resetar</string>
     <string name="floyd_steninberg_initials">FS</string>
@@ -11,6 +7,7 @@
     <string name="rotate">Rotacionar</string>
     <string name="invert">Inverter</string>
 
+    <string name="static_tool">Estático</string>
     <string name="generate">Gerar</string>
     <string name="not_binary_image">Não é uma imagem binária. Certifique-se que todos os pixels sejam pretos ou brancos.</string>
     <string name="generate_image_page">Gerar uma página de imagem</string>
@@ -51,5 +48,7 @@
     <string name="hello_my_name_is">Olá, meu nome é</string>
     <string name="upcoming_weather">☀️Previsão do tempo</string>
     <string name="quote_of_the_day">Mensagem do dia</string>
+    <string name="send_icon_text">Enviar</string>
+    <string name="badge_config_editor_title">Editar configuração do crachá</string>
 
 </resources>

--- a/zeapp/android/src/main/res/values-pt-rBR/strings.xml
+++ b/zeapp/android/src/main/res/values-pt-rBR/strings.xml
@@ -51,4 +51,10 @@
     <string name="send_icon_text">Enviar</string>
     <string name="badge_config_editor_title">Editar configuração do crachá</string>
 
+
+    <string name="ze_navdrawer_save_all_pages">Salvar todas as páginas no crachá</string>
+    <string name="ze_navdrawer_update_config">Atualizar configuração no crachá</string>
+    <string name="ze_navdrawer_send_random_page">Enviar página aleatória para o crachá</string>
+    <string name="ze_navdrawer_open_release_page">Abrir página de lançamentos</string>
+
 </resources>

--- a/zeapp/android/src/main/res/values/strings.xml
+++ b/zeapp/android/src/main/res/values/strings.xml
@@ -51,4 +51,9 @@
     <string name="quote_of_the_day" tools:ignore="MissingTranslation">Quote of The Day</string>
     <string name="send_icon_text" tools:ignore="MissingTranslation">Send</string>
     <string name="badge_config_editor_title">Edit Badge Configuration</string>
+
+    <string name="ze_navdrawer_save_all_pages">Save all pages to badge</string>
+    <string name="ze_navdrawer_update_config">Update config on badge</string>
+    <string name="ze_navdrawer_send_random_page">Send random page to badge</string>
+    <string name="ze_navdrawer_open_release_page">Open release page</string>
 </resources>


### PR DESCRIPTION
## Summary

This PR improves the current PT_BR Localization, adding new translations and removing `untranslatable` strings. Also,  I started fixing the string resource use on Compose.

## How It Was Tested

Ran project.

## Screenshot/Gif
<img src="https://github.com/gdg-berlin-android/ZeBadge/assets/2752808/62c836b1-a53a-4933-8b35-4776a77a34ad" height=480 />