### PR TITLE
Adding string resources to compose + new translations

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
@@ -628,7 +628,7 @@ private fun ZePages(
 @Composable
 @Preview
 private fun InfoBar(
-    message: String = "Very Important",
+    message: String = stringResource(id = R.string.ze_very_important),
     progress: Float = 0.5f,
     copyMoreToClipboard: (() -> Unit) = {},
 ) {
@@ -680,9 +680,9 @@ private fun InfoBar(
 @Preview
 private fun BadgeConfigEditor(
     config: Map<String, Any?> = mapOf(
-        "sample configuration" to "sample value",
-        "sample int" to 23,
-        "another configuration" to true,
+        stringResource(id = R.string.ze_sample_configuration_key) to stringResource(id = R.string.ze_sample_configuration_value),
+        stringResource(id = R.string.ze_sample_int_key) to 23,
+        stringResource(id = R.string.ze_sample_another_configuration_key) to true,
     ),
     onDismissRequest: () -> Unit = {},
     onConfirmed: (updateConfig: Map<String, Any?>) -> Unit = {},
@@ -799,7 +799,7 @@ private fun SelectedEditor(
             )
 
             is ZeConfiguration.Schedule -> {
-                vm.showMessage(message = "Not added by you yet, please feel free to contribute this editor")
+                vm.showMessage(message = stringResource(id = R.string.ze_not_added_yet_message))
                 vm.slotConfigured(null, null)
             }
 
@@ -872,7 +872,7 @@ private fun TemplateChooserDialog(
         title = {
             ZeText(
                 color = ZeBlack,
-                text = "Select Content",
+                text = stringResource(id = R.string.ze_select_content),
             )
         },
         text = {
@@ -943,7 +943,7 @@ private fun PagePreview(
                         item {
                             ZeToolButton(
                                 imageVector = Icons.AutoMirrored.Filled.Send,
-                                text = "Send",
+                                text = stringResource(id = R.string.send),
                                 onClick = sendToDevice,
                             )
                         }
@@ -952,7 +952,7 @@ private fun PagePreview(
                         item {
                             ZeToolButton(
                                 imageVector = Icons.Filled.Refresh,
-                                text = "Reset",
+                                text = stringResource(id = R.string.reset),
                                 onClick = resetThisPage,
                             )
                         }
@@ -961,7 +961,7 @@ private fun PagePreview(
                         item {
                             ZeToolButton(
                                 imageVector = Icons.Filled.Edit,
-                                text = "Edit",
+                                text = stringResource(id = R.string.ze_edit),
                                 onClick = customizeThisPage,
                             )
                         }

--- a/zeapp/android/src/main/res/values-pt-rBR/strings.xml
+++ b/zeapp/android/src/main/res/values-pt-rBR/strings.xml
@@ -2,10 +2,12 @@
 <resources>
     <string name="black_and_white">P/B</string>
     <string name="reset">Resetar</string>
+    <string name="ze_edit">Editar</string>
     <string name="floyd_steninberg_initials">FS</string>
     <string name="positional">Posicional</string>
     <string name="rotate">Rotacionar</string>
     <string name="invert">Inverter</string>
+    <string name="ze_very_important">Muito importante</string>
 
     <string name="static_tool">Estático</string>
     <string name="generate">Gerar</string>
@@ -56,5 +58,12 @@
     <string name="ze_navdrawer_update_config">Atualizar configuração no crachá</string>
     <string name="ze_navdrawer_send_random_page">Enviar página aleatória para o crachá</string>
     <string name="ze_navdrawer_open_release_page">Abrir página de lançamentos</string>
+    <string name="ze_select_content">Selecione o conteúdo</string>
+    <string name="ze_not_added_yet_message">Ainda não foi adicionado por você, sinta-se livre para contribuir com esse editor</string>
+
+    <string name="ze_sample_configuration_key">Exemplo de configuração</string>
+    <string name="ze_sample_configuration_value">Exemplo de valor</string>
+    <string name="ze_sample_int_key">Exemplo de int</string>
+    <string name="ze_sample_another_configuration_key">Outra configuração</string>
 
 </resources>

--- a/zeapp/android/src/main/res/values/strings.xml
+++ b/zeapp/android/src/main/res/values/strings.xml
@@ -4,11 +4,13 @@
 
     <string name="black_and_white">B/W</string>
     <string name="reset">Reset</string>
+    <string name="ze_edit">Edit</string>
     <string name="floyd_steninberg_initials">FS</string>
     <string name="positional">Positional</string>
     <string name="rotate">Rotate</string>
     <string name="invert">Invert</string>
     <string name="static_tool">Static</string>
+    <string name="ze_very_important" tools:ignore="MissingTranslation">Very Important</string>
 
     <string name="generate">Generate</string>
     <string name="not_binary_image">Not a binary image. Make sure each pixel is either black or white.</string>
@@ -56,4 +58,11 @@
     <string name="ze_navdrawer_update_config">Update config on badge</string>
     <string name="ze_navdrawer_send_random_page">Send random page to badge</string>
     <string name="ze_navdrawer_open_release_page">Open release page</string>
+    <string name="ze_select_content" tools:ignore="MissingTranslation">Select Content</string>
+    <string name="ze_not_added_yet_message" tools:ignore="MissingTranslation">Not added by you yet, please feel free to contribute this editor</string>
+
+    <string name="ze_sample_configuration_key" tools:ignore="MissingTranslation">sample configuration</string>
+    <string name="ze_sample_configuration_value" tools:ignore="MissingTranslation">sample value</string>
+    <string name="ze_sample_int_key" tools:ignore="MissingTranslation">sample int</string>
+    <string name="ze_sample_another_configuration_key" tools:ignore="MissingTranslation">another configuration</string>
 </resources>


### PR DESCRIPTION
## Summary

This PR makes Compose use of the existing string resources in the project. It also adds new Portuguese translations.

## How It Was Tested

- Manual testing.

## Screenshot/Gif

<img src="https://github.com/gdg-berlin-android/ZeBadge/assets/2752808/b9b773e0-c8f1-4ee1-942b-18628eea0ec7" height=480 />

<img src="https://github.com/gdg-berlin-android/ZeBadge/assets/2752808/83321bf9-ba0b-4f2f-b0e9-9572ec503334" height=480 />
