### PR TITLE
[254] Fix Accessibility issues. Start fixing the Light color theme as it's broken

### DIFF
--- a/zeapp/android/src/main/java/com/ban/autosizetextfield/AutoSizeTextField.kt
+++ b/zeapp/android/src/main/java/com/ban/autosizetextfield/AutoSizeTextField.kt
@@ -88,6 +88,8 @@ fun AutoSizeTextField(
                 cursorColor = ZeWhite,
                 errorContainerColor = Color.Red,
                 errorLabelColor = Color.Red,
+                focusedSupportingTextColor = ZeBlack,
+                unfocusedSupportingTextColor = ZeBlack
             ),
         )
     }

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
@@ -896,7 +896,7 @@ private fun PagePreview(
         modifier = modifier
             .padding(ZeDimen.Quarter),
         colors = CardDefaults.cardColors(
-            containerColor = ZeBlack,
+            containerColor = MaterialTheme.colorScheme.surface,
             contentColor = ZeWhite,
         ),
         border = BorderStroke(1.dp, ZeWhite),

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zetheme/ZeTheme.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zetheme/ZeTheme.kt
@@ -28,9 +28,11 @@ private val LightColorScheme = lightColorScheme(
     secondary = ZePurple,
     onPrimary = ZeWhite,
     onSecondary = ZeBlack,
+    surface = ZeGrey,
+    onSurface = ZeBlack,
+    background = ZeWhite,
     error = ZeCarmine,
     onError = ZeWhite,
-    background = ZeWhite,
     onBackground = ZeBlack,
 )
 


### PR DESCRIPTION


## Summary

Ticket 254 say that there are acessibility issues with the helper text when entering name on the Contact edit card. This PR fixes this. It also starts addressing wrong colors used in the Light theme of the app.

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

## Screenshot/Gif

<!-- If applicable, show off the user facing changes. -->

<details>

<summary>Screenshot Name</summary>

<!-- file here -->

</details>