### PR TITLE
Small style updates

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
@@ -250,9 +250,7 @@ private fun ZeScreen(vm: ZeBadgeViewModel, modifier: Modifier = Modifier) {
 
     BackHandler(drawerState.isOpen || currentRoute != ROUTE_HOME) {
         if (drawerState.isOpen) {
-            scope.launch {
-                drawerState.close()
-            }
+            scope.launch { drawerState.close() }
         } else {
             navController.navigateUp()
         }
@@ -288,9 +286,7 @@ private fun ZeScreen(vm: ZeBadgeViewModel, modifier: Modifier = Modifier) {
                     modifier = modifier,
                     floatingActionButton = {
                         if (currentRoute == ROUTE_HOME) {
-                            ZeNavigationPad(
-                                lazyListState,
-                            )
+                            ZeNavigationPad(lazyListState)
                         }
                     },
                     topBar = {

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -32,7 +33,6 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.Send
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.Edit
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Menu
@@ -528,9 +528,7 @@ private fun ZePages(
     lazyListState: LazyListState,
 ) {
     ZeSurface(
-        modifier = ZeModifier
-            .fillMaxSize()
-            .padding(paddingValues),
+        modifier = ZeModifier.fillMaxSize(),
     ) {
         val uiState by vm.uiState.collectAsState() // should be replace with 'collectAsStateWithLifecycle'
         val isKeyboardVisible by isKeyboardVisibleState()
@@ -552,15 +550,18 @@ private fun ZePages(
                 config = badgeConfiguration,
                 onDismissRequest = vm::closeConfiguration,
                 onConfirmed = vm::updateConfiguration,
+                modifier = Modifier.padding(paddingValues),
             )
         }
 
         if (editor != null) {
-            SelectedEditor(editor, vm)
+            Box(Modifier.padding(paddingValues)) {
+                SelectedEditor(editor, vm)
+            }
         }
 
         if (templateChooser != null) {
-            TemplateChooserDialog(vm, templateChooser)
+            TemplateChooserDialog(vm, templateChooser, modifier = Modifier.padding(paddingValues))
         }
 
         // column surrounding a lazycolumn: so the message stays ontop.
@@ -571,12 +572,7 @@ private fun ZePages(
 
             ZeLazyColumn(
                 state = lazyListState,
-                contentPadding = PaddingValues(
-                    start = ZeDimen.One,
-                    end = ZeDimen.One,
-                    top = ZeDimen.Half,
-                    bottom = ZeDimen.One,
-                ),
+                contentPadding = paddingValues,
             ) {
                 items(
                     slots.keys.toList(),
@@ -674,6 +670,7 @@ private fun InfoBar(
 @Composable
 @Preview
 private fun BadgeConfigEditor(
+    modifier: Modifier = Modifier,
     config: Map<String, Any?> = mapOf(
         stringResource(id = R.string.ze_sample_configuration_key) to stringResource(id = R.string.ze_sample_configuration_value),
         stringResource(id = R.string.ze_sample_int_key) to 23,
@@ -686,7 +683,7 @@ private fun BadgeConfigEditor(
     var error by remember { mutableStateOf(mapOf<String, String>()) }
 
     AlertDialog(
-        modifier = Modifier.imePadding(),
+        modifier = modifier.imePadding(),
         onDismissRequest = onDismissRequest,
         confirmButton = {
             Button(
@@ -855,8 +852,10 @@ private fun SelectedEditor(
 private fun TemplateChooserDialog(
     vm: ZeBadgeViewModel,
     templateChooser: ZeTemplateChooser?,
+    modifier: Modifier = Modifier,
 ) {
     ZeAlertDialog(
+        modifier = modifier,
         containerColor = ZeWhite,
         onDismissRequest = {
             vm.templateSelected(null, null)

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
@@ -248,7 +248,15 @@ private fun ZeScreen(vm: ZeBadgeViewModel, modifier: Modifier = Modifier) {
     val currentNavBackStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = currentNavBackStackEntry?.destination?.route ?: ROUTE_HOME
 
-    BackHandler(currentRoute != ROUTE_HOME) { navController.navigateUp() }
+    BackHandler(drawerState.isOpen || currentRoute != ROUTE_HOME) {
+        if (drawerState.isOpen) {
+            scope.launch {
+                drawerState.close()
+            }
+        } else {
+            navController.navigateUp()
+        }
+    }
 
     ZeBadgeAppTheme(
         content = {

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
@@ -335,6 +335,12 @@ private fun ZeDrawerContent(
         painter: Painter? = null,
         onClick: () -> Unit,
     ) {
+        val shape = RoundedCornerShape(
+            topStart = 0.dp,
+            bottomStart = 0.dp,
+            topEnd = 30.dp,
+            bottomEnd = 30.dp,
+        )
         NavigationDrawerItem(
             modifier = Modifier
                 .padding(
@@ -346,17 +352,13 @@ private fun ZeDrawerContent(
                 .border(
                     width = 1.dp,
                     color = ZeWhite,
-                    shape = RoundedCornerShape(
-                        topStart = 0.dp,
-                        bottomStart = 0.dp,
-                        topEnd = 30.dp,
-                        bottomEnd = 30.dp,
-                    ),
+                    shape = shape,
                 ),
             colors = NavigationDrawerItemDefaults.colors(
                 unselectedTextColor = ZeWhite,
                 unselectedContainerColor = ZeBlack,
             ),
+            shape = shape,
             icon = {
                 if (vector != null) {
                     ZeIcon(imageVector = vector, contentDescription = text, tint = ZeWhite)
@@ -418,10 +420,9 @@ private fun ZeDrawerContent(
             item {
                 HorizontalDivider(
                     thickness = 0.dp,
-                    color = ZeBlack,
+                    color = MaterialTheme.colorScheme.background,
                     modifier = Modifier.padding(
-                        start = 0.dp,
-                        end = 40.dp, top = 16.dp, bottom = 16.dp,
+                        start = 0.dp, end = 0.dp, top = 16.dp, bottom = 16.dp,
                     ),
                 )
             }
@@ -445,10 +446,9 @@ private fun ZeDrawerContent(
             item {
                 HorizontalDivider(
                     thickness = 0.dp,
-                    color = ZeBlack,
+                    color = MaterialTheme.colorScheme.background,
                     modifier = Modifier.padding(
-                        start = 0.dp,
-                        end = 40.dp, top = 16.dp, bottom = 16.dp,
+                        start = 0.dp, end = 0.dp, top = 16.dp, bottom = 16.dp,
                     ),
                 )
             }

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zeabout/ZeAboutScreen.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zeabout/ZeAboutScreen.kt
@@ -2,11 +2,16 @@ package de.berlindroid.zeapp.zeui.zeabout
 
 import android.content.Intent
 import android.net.Uri
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -23,6 +28,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -30,6 +36,7 @@ import de.berlindroid.zeapp.R
 import de.berlindroid.zeapp.ZeDimen
 import de.berlindroid.zekompanion.getPlatform
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ZeAbout(
     paddingValues: PaddingValues,
@@ -41,43 +48,55 @@ fun ZeAbout(
     Surface(
         modifier = Modifier
             .fillMaxSize()
-            .padding(paddingValues)
             .padding(ZeDimen.Half),
     ) {
-        Column {
-            Text(
-                text = "${lines.count()} contributors",
-                modifier = Modifier.padding(8.dp),
-                style = MaterialTheme.typography.bodyMedium,
-                fontSize = 24.sp,
-            )
-            Text(
-                text = "Running on '${getPlatform()}'.",
-            )
-            LazyColumn(Modifier.fillMaxWidth()) {
-                items(lines) { line ->
-                    Row(
-                        verticalAlignment = Alignment.CenterVertically,
-                    ) {
-                        val email = line.substring(line.indexOf('<').plus(1), line.lastIndexOf('>')).trim()
-                        Text(
-                            text = line.substring(0, line.indexOf('<')).trim(),
-                            color = MaterialTheme.colorScheme.onSurface,
-                            modifier = Modifier.padding(8.dp),
-                            style = MaterialTheme.typography.bodyMedium,
-                            fontSize = 18.sp,
-                        )
-                        Icon(
-                            painter = painterResource(id = R.drawable.email),
-                            contentDescription = "Send random page to badge",
-                            Modifier
-                                .size(20.dp, 20.dp)
-                                .clickable {
-                                    val intent = Intent(Intent.ACTION_VIEW, Uri.parse("mailto:$email"))
-                                    context.startActivity(intent)
-                                },
-                        )
-                    }
+        LazyColumn(
+            modifier = Modifier.fillMaxWidth().padding(top = paddingValues.calculateTopPadding()),
+            contentPadding = PaddingValues(
+                start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
+                end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                bottom = paddingValues.calculateBottomPadding(),
+            ),
+        ) {
+            stickyHeader {
+                Column(
+                    Modifier
+                        .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)),
+                ) {
+                    Text(
+                        text = "${lines.count()} contributors",
+                        modifier = Modifier.padding(8.dp),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontSize = 24.sp,
+                    )
+                    Text(
+                        text = "Running on '${getPlatform()}'.",
+                        modifier = Modifier.padding(8.dp),
+                    )
+                }
+            }
+            items(lines) { line ->
+                Row(
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    val email = line.substring(line.indexOf('<').plus(1), line.lastIndexOf('>')).trim()
+                    Text(
+                        text = line.substring(0, line.indexOf('<')).trim(),
+                        color = MaterialTheme.colorScheme.onSurface,
+                        modifier = Modifier.padding(8.dp),
+                        style = MaterialTheme.typography.bodyMedium,
+                        fontSize = 18.sp,
+                    )
+                    Icon(
+                        painter = painterResource(id = R.drawable.email),
+                        contentDescription = "Send random page to badge",
+                        Modifier
+                            .size(20.dp, 20.dp)
+                            .clickable {
+                                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("mailto:$email"))
+                                context.startActivity(intent)
+                            },
+                    )
                 }
             }
         }

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zeabout/ZeAboutScreen.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zeabout/ZeAboutScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -48,10 +47,11 @@ fun ZeAbout(
     Surface(
         modifier = Modifier
             .fillMaxSize()
-            .padding(ZeDimen.Half),
     ) {
         LazyColumn(
-            modifier = Modifier.fillMaxWidth().padding(top = paddingValues.calculateTopPadding()),
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(top = paddingValues.calculateTopPadding()),
             contentPadding = PaddingValues(
                 start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
                 end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zetheme/ZeTheme.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zetheme/ZeTheme.kt
@@ -7,8 +7,6 @@ import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 
@@ -19,8 +17,8 @@ private val DarkColorScheme = darkColorScheme(
     onSecondary = ZeWhite,
     error = ZeWhite,
     onError = ZeBlack,
-    background = ZeWhite,
-    onBackground = ZeBlack,
+    background = ZeBlack,
+    onBackground = ZeWhite,
 )
 
 private val LightColorScheme = lightColorScheme(


### PR DESCRIPTION
## Warnings

This PR depends on: https://github.com/gdg-berlin-android/ZeBadge/pull/288

## Summary

- update dark theme to use black as background and white as onbackground (to have a better dark experience)
- make edgeToEdge actually edge to edge by using content padding on the lazyColumns (so things scroll behind the nav bar)
- restructure the `ZeAbout` screen to have sticky header and items scroll behind sticky header and bottom bar
- make drawer items match the shape of the border 
- make divider full width

## How It Was Tested

Use dark and light theme with a device. 
Drawer items look more refine in light theme (e.g. the shape matches the border)

## Screenshot/Gif

<img width="210" alt="Screenshot 2024-07-03 at 21 43 28" src="https://github.com/gdg-berlin-android/ZeBadge/assets/1476232/6368f313-7ca6-4d51-813e-b7a6a08ea8bb">
<img width="221" alt="Screenshot 2024-07-03 at 21 43 44" src="https://github.com/gdg-berlin-android/ZeBadge/assets/1476232/27bab31e-f014-4b7d-ae89-15716e77b7d6">
<img width="214" alt="Screenshot 2024-07-03 at 21 44 58" src="https://github.com/gdg-berlin-android/ZeBadge/assets/1476232/2009a54e-eea2-491b-a344-0519f5c2f4f7">

