### PR TITLE
resolve contentDescription issue on ZeToolButtons

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeToolButton.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeToolButton.kt
@@ -71,9 +71,10 @@ fun ToolButton(
     TextButton(
         onClick = onClick,
         modifier = Modifier.wrapContentHeight(),
+        
     ) {
         Column(
-            modifier = Modifier.wrapContentHeight(),
+            modifier = Modifier.wrapContentHeight().semantics(mergeDescendants = true) {},
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeToolButton.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeToolButton.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.semantics
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.sp
 import androidx.core.R


### PR DESCRIPTION
## Summary

Resolve #255 contentDescription warnings in ZeToolButtons, via https://developer.android.com/develop/ui/compose/accessibility/key-steps#merge-elements

## How It Was Tested

Untested due to lack of laptop with Studio, hoping GH Actions pass :)

## Screenshot/Gif

<!-- If applicable, show off the user facing changes. -->

<details>

<summary>Screenshot Name</summary>

<!-- file here -->

</details>