### PR TITLE
[conflict] Added Share feature in gallery

### DIFF
--- a/zeapp/android/src/main/AndroidManifest.xml
+++ b/zeapp/android/src/main/AndroidManifest.xml
@@ -28,6 +28,12 @@
 
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.SEND" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:mimeType="image/*" />
+            </intent-filter>
         </activity>
 
         <provider

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/ZeMainActivity.kt
@@ -22,7 +22,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
-import androidx.compose.foundation.layout.consumeWindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zebits/ZeImageLoader.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zebits/ZeImageLoader.kt
@@ -1,0 +1,48 @@
+package de.berlindroid.zeapp.zebits
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.Color
+import android.graphics.drawable.BitmapDrawable
+import android.net.Uri
+import coil.imageLoader
+import coil.request.CachePolicy
+import coil.request.ImageRequest
+import coil.size.Precision
+import coil.size.Scale
+import com.commit451.coiltransformations.CropTransformation
+import de.berlindroid.zeapp.zeui.pixelManipulation
+import de.berlindroid.zekompanion.BADGE_HEIGHT
+import de.berlindroid.zekompanion.BADGE_WIDTH
+import de.berlindroid.zekompanion.ditherFloydSteinberg
+
+suspend fun Uri.toDitheredImage(context: Context): Bitmap {
+    val imageRequest = ImageRequest.Builder(context)
+        .data(this)
+        .transformations(CropTransformation())
+        .size(BADGE_WIDTH, BADGE_HEIGHT)
+        .scale(Scale.FIT)
+        .precision(Precision.EXACT)
+        .allowHardware(false)
+        .memoryCachePolicy(CachePolicy.DISABLED)
+        .diskCachePolicy(CachePolicy.DISABLED)
+        .build()
+
+    val drawable = context.imageLoader.execute(imageRequest).drawable as BitmapDrawable
+    val bitmap = Bitmap.createBitmap(
+        BADGE_WIDTH,
+        BADGE_HEIGHT,
+        Bitmap.Config.ARGB_8888,
+    )
+    val canvas = Canvas(bitmap)
+    canvas.drawColor(Color.WHITE)
+    canvas.drawBitmap(
+        drawable.bitmap,
+        (BADGE_WIDTH / 2f) - (drawable.bitmap.width / 2f),
+        0f,
+        null,
+    )
+
+    return bitmap.pixelManipulation { w, h -> ditherFloydSteinberg(w, h) }
+}

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeCameraEditor.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeCameraEditor.kt
@@ -1,9 +1,5 @@
 package de.berlindroid.zeapp.zeui
 
-import android.graphics.Bitmap
-import android.graphics.Canvas
-import android.graphics.Color
-import android.graphics.drawable.BitmapDrawable
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.runtime.Composable
@@ -11,19 +7,11 @@ import androidx.compose.runtime.SideEffect
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.core.content.FileProvider
-import coil.imageLoader
-import coil.request.CachePolicy
-import coil.request.ImageRequest
-import coil.size.Precision
-import coil.size.Scale
-import com.commit451.coiltransformations.CropTransformation
 import de.berlindroid.zeapp.BuildConfig
-import de.berlindroid.zekompanion.BADGE_HEIGHT
-import de.berlindroid.zekompanion.BADGE_WIDTH
+import de.berlindroid.zeapp.zebits.toDitheredImage
 import de.berlindroid.zeapp.zemodels.ZeConfiguration
 import de.berlindroid.zeapp.zemodels.ZeEditor
 import de.berlindroid.zeapp.zevm.ZeBadgeViewModel
-import de.berlindroid.zekompanion.ditherFloydSteinberg
 import kotlinx.coroutines.launch
 import java.io.File
 
@@ -43,36 +31,11 @@ fun ZeCameraEditor(
     val takePicture =
         rememberLauncherForActivityResult(ActivityResultContracts.TakePicture()) { pictureTaken ->
             if (pictureTaken) {
-                val imageRequest = ImageRequest.Builder(context)
-                    .data(uri)
-                    .transformations(CropTransformation())
-                    .size(BADGE_WIDTH, BADGE_HEIGHT)
-                    .scale(Scale.FIT)
-                    .precision(Precision.EXACT)
-                    .allowHardware(false)
-                    .memoryCachePolicy(CachePolicy.DISABLED)
-                    .diskCachePolicy(CachePolicy.DISABLED)
-                    .build()
-
                 coroutineScope.launch {
-                    val drawable =
-                        context.imageLoader.execute(imageRequest).drawable as BitmapDrawable
-                    val bitmap = Bitmap.createBitmap(
-                        BADGE_WIDTH,
-                        BADGE_HEIGHT,
-                        Bitmap.Config.ARGB_8888,
-                    )
-                    val canvas = Canvas(bitmap)
-                    canvas.drawColor(Color.WHITE)
-                    canvas.drawBitmap(
-                        drawable.bitmap,
-                        (BADGE_WIDTH / 2f) - (drawable.bitmap.width / 2f),
-                        0f,
-                        null,
-                    )
+                    val bitmap = uri.toDitheredImage(context)
                     vm.slotConfigured(
                         editor.slot,
-                        config.copy(bitmap = bitmap.pixelManipulation { w, h -> ditherFloydSteinberg(w, h) }),
+                        config.copy(bitmap = bitmap),
                     )
                 }
             } else {


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->
- Added share intent from gallery to receive images
- Refactor uri to bitmap conversion flow

## How It Was Tested

<!-- Explain how you tested this change before merging. -->
1. Go to any image in your gallery
2. Click on Share and choose Ze Androft App
3. This would open the Ze Androft App. Now, the camera slot should have the selected image in dithered format.

## Screenshot/Gif

<!-- If applicable, show off the user facing changes. -->
![image](https://github.com/gdg-berlin-android/ZeBadge/assets/46375353/6568e653-c07c-400e-8394-b7fafab8be8b)
![image](https://github.com/gdg-berlin-android/ZeBadge/assets/46375353/ec813cde-df9e-44eb-9f12-aebc72aa1cfe)

