### PR TITLE
Stretch contributors list width.

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zeabout/ZeAboutScreen.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zeabout/ZeAboutScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
@@ -53,7 +54,7 @@ fun ZeAbout(
             Text(
                 text = "Running on '${getPlatform()}'.",
             )
-            LazyColumn {
+            LazyColumn(Modifier.fillMaxWidth()) {
                 items(lines) { line ->
                     Row(
                         verticalAlignment = Alignment.CenterVertically,


### PR DESCRIPTION
## Summary

Without it the touch to scroll the list only works if directly touching the names themselves.
    
Now when right-hand holding and scrolling with the thumb works reliably.

## How It Was Tested

Emulator and device. Tested before and after.
