### PR TITLE
Use gradle/actions/setup-gradle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,8 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Assemble Release
@@ -67,7 +68,8 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Lint
@@ -82,7 +84,8 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: 17
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: Validate Gradle wrapper
         uses: gradle/wrapper-validation-action@v1
       - name: Detekt

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -20,9 +20,10 @@ jobs:
       - name: "Setup Java 17"
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: 17
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: "Validate Gradle wrapper"
         uses: gradle/wrapper-validation-action@v1
       - name: "Assemble Debug"
@@ -41,9 +42,10 @@ jobs:
       - name: "Setup Java 17"
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: 17
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: "Validate Gradle wrapper"
         uses: gradle/wrapper-validation-action@v1
       - name: "Lint"
@@ -57,9 +59,10 @@ jobs:
       - name: "Setup Java 17"
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: 17
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: "Validate Gradle wrapper"
         uses: gradle/wrapper-validation-action@v1
       - name: "Lint"
@@ -72,9 +75,10 @@ jobs:
       - name: "Setup Java 17"
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: 17
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: "Validate Gradle wrapper"
         uses: gradle/wrapper-validation-action@v1
       - name: "Detekt"
@@ -87,11 +91,11 @@ jobs:
       - name: "Setup Java 17"
         uses: actions/setup-java@v3
         with:
-          distribution: 'temurin'
+          distribution: "temurin"
           java-version: 17
-          cache: 'gradle'
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v3
       - name: "Validate Gradle wrapper"
         uses: gradle/wrapper-validation-action@v1
       - name: "Test"
         run: ./gradlew linuxTest
-    


### PR DESCRIPTION
## Summary

This moves GHA setup to don't use `cache: 'gradle'` from setup-java
but use instead `gradle/actions/setup-gradle`.

This rationale behind this is explained here:
https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#why-use-the-setup-gradle-action

## How It Was Tested

CI Signals
