### PR TITLE
Add typed badge payloads

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeservices/ZeBadgeManager.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeservices/ZeBadgeManager.kt
@@ -5,6 +5,7 @@ import android.graphics.Bitmap
 import dagger.hilt.android.qualifiers.ApplicationContext
 import de.berlindroid.zeapp.zeui.pixelBuffer
 import de.berlindroid.zekompanion.*
+import de.berlindroid.zekompanion.BadgePayload.*
 import kotlinx.coroutines.delay
 import timber.log.Timber
 import javax.inject.Inject
@@ -30,9 +31,7 @@ class ZeBadgeManager @Inject constructor(
             .zipit()
             .base64()
 
-        val payload = BadgePayload(
-            type = "preview",
-            meta = "",
+        val payload = PreviewPayload(
             payload = binaryPayload,
         )
 
@@ -52,9 +51,8 @@ class ZeBadgeManager @Inject constructor(
             .zipit()
             .base64()
 
-        val payload = BadgePayload(
-            type = "store",
-            meta = name,
+        val payload = StorePayload(
+            filename = name,
             payload = binaryPayload,
         )
 
@@ -67,10 +65,8 @@ class ZeBadgeManager @Inject constructor(
      * @param name a file name on the badge to be shown
      */
     suspend fun showPage(name: String): Result<Int> {
-        val payload = BadgePayload(
-            type = "show",
-            meta = name,
-            payload = "",
+        val payload = ShowPayload(
+            filename = name
         )
 
         return badgeManager.sendPayload(payload)
@@ -80,11 +76,7 @@ class ZeBadgeManager @Inject constructor(
      * Return the name of the pages stored on the badge.
      */
     suspend fun requestPagesStored(): Result<String> {
-        val payload = BadgePayload(
-            type = "list",
-            meta = "",
-            payload = "",
-        )
+        val payload = ListPayload()
 
         return if (badgeManager.sendPayload(payload).isSuccess) {
             badgeManager.readResponse()
@@ -98,21 +90,13 @@ class ZeBadgeManager @Inject constructor(
      */
     suspend fun listConfiguration(): Result<Map<String, Any?>> {
         badgeManager.sendPayload(
-            BadgePayload(
-                type = "config_load",
-                meta = "",
-                payload = "",
-            ),
+            ConfigLoadPayload(),
         )
 
         badgeManager.readResponse()
         delay(300)
 
-        val payload = BadgePayload(
-            type = "config_list",
-            meta = "",
-            payload = "",
-        )
+        val payload = ConfigListPayload()
 
         if (badgeManager.sendPayload(payload).isSuccess) {
             val response = badgeManager.readResponse()
@@ -148,10 +132,8 @@ class ZeBadgeManager @Inject constructor(
 
         val config = detypedConfig.entries.joinToString(separator = " ")
 
-        val payload = BadgePayload(
-            type = "config_update",
-            meta = "",
-            payload = config,
+        val payload = ConfigUpdatePayload(
+            config = config,
         )
 
         if (badgeManager.sendPayload(payload).isSuccess) {
@@ -159,11 +141,7 @@ class ZeBadgeManager @Inject constructor(
             delay(300)
 
             return if (badgeManager.sendPayload(
-                    BadgePayload(
-                        type = "config_save",
-                        meta = "",
-                        payload = "",
-                    ),
+                    ConfigSavePayload(),
                 ).isSuccess
             ) {
                 Result.success(true)

--- a/zeapp/badge/src/commonMain/kotlin/de/berlindroid/zekompanion/BadgeManager.kt
+++ b/zeapp/badge/src/commonMain/kotlin/de/berlindroid/zekompanion/BadgeManager.kt
@@ -7,8 +7,8 @@ package de.berlindroid.zekompanion
  * @param meta any meta information you want to receive back?
  * @param payload the payload of the command of type 'type'.
  */
-data class BadgePayload(
-    val debug: Boolean = false,
+sealed class BadgePayload(
+    val debug: Boolean,
     val type: String,
     val meta: String,
     val payload: String,
@@ -17,6 +17,66 @@ data class BadgePayload(
      * Convert the payload to a format the badge understands
      */
     fun toBadgeCommand(): String = "${if (debug) "debug:" else ""}$type:$meta:${payload}"
+
+    class RawPayload(debug: Boolean = false, type: String, meta: String, payload: String) : BadgePayload(
+        debug, type, meta, payload,
+    )
+
+    class HelpPayload(debug: Boolean = false) : BadgePayload(
+        debug, type = "help", meta = "", payload = "",
+    )
+
+    class ReloadPayload(debug: Boolean = false) : BadgePayload(
+        debug, type = "reload", meta = "", payload = "",
+    )
+
+    class ExitPayload(debug: Boolean = false) : BadgePayload(
+        debug, type = "exit", meta = "", payload = "",
+    )
+
+    class TerminalPayload(debug: Boolean = false) : BadgePayload(
+        debug, type = "terminal", meta = "", payload = "",
+    )
+
+    class RefreshPayload(debug: Boolean = false) : BadgePayload(
+        debug, type = "refresh", meta = "", payload = "",
+    )
+
+    class ConfigSavePayload(debug: Boolean = false) : BadgePayload(
+        debug, type = "config_save", meta = "", payload = "",
+    )
+
+    class ConfigLoadPayload(debug: Boolean = false) : BadgePayload(
+        debug, type = "config_load", meta = "", payload = "",
+    )
+
+    class ConfigUpdatePayload(debug: Boolean = false, config: String) : BadgePayload(
+        debug, type = "config_update", meta = "", payload = config,
+    )
+
+    class ConfigListPayload(debug: Boolean = false) : BadgePayload(
+        debug, type = "config_list", meta = "", payload = "",
+    )
+
+    class ShowPayload(debug: Boolean = false, filename: String) : BadgePayload(
+        debug, type = "show", meta = filename, payload = "",
+    )
+
+    class StorePayload(debug: Boolean = false, filename: String, payload: String) : BadgePayload(
+        debug, type = "store", meta = filename, payload = payload,
+    )
+
+    class PreviewPayload(debug: Boolean = false, payload: String) : BadgePayload(
+        debug, type = "preview", meta = "", payload = payload,
+    )
+
+    class ListPayload(debug: Boolean = false) : BadgePayload(
+        debug, type = "list", meta = "", payload = "",
+    )
+
+    class DeletePayload(debug: Boolean = false, filename: String) : BadgePayload(
+        debug, type = "delete", meta = filename, payload = "",
+    )
 }
 
 interface BadgeManager {

--- a/zeapp/desktop/src/main/kotlin/de/berlindroid/zekompanion/desktop/ZeBadgeKompanion.kt
+++ b/zeapp/desktop/src/main/kotlin/de/berlindroid/zekompanion/desktop/ZeBadgeKompanion.kt
@@ -8,7 +8,6 @@ import androidx.compose.ui.awt.ComposePanel
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.window.Window
 import androidx.compose.ui.window.application
-import de.berlindroid.zekompanion.BadgePayload
 import de.berlindroid.zekompanion.base64
 import de.berlindroid.zekompanion.buildBadgeManager
 import de.berlindroid.zekompanion.desktop.ui.DrawNameBadge
@@ -20,6 +19,7 @@ import de.berlindroid.zekompanion.resize
 import de.berlindroid.zekompanion.toBinary
 import de.berlindroid.zekompanion.BADGE_WIDTH
 import de.berlindroid.zekompanion.BADGE_HEIGHT
+import de.berlindroid.zekompanion.BadgePayload.*
 import de.berlindroid.zekompanion.zipit
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
@@ -161,10 +161,8 @@ private fun sendImageToBadge(image: BufferedImage, callback: (Result<Int>) -> Un
         GlobalScope.launch {
             with(buildBadgeManager("")) {
                 if (isConnected()) {
-                    val payload = BadgePayload(
+                    val payload = PreviewPayload(
                         debug = false,
-                        type = "preview",
-                        meta = "",
                         image.toPayload(),
                     )
 

--- a/zeapp/server/src/main/kotlin/de/berlindroid/zekompanion/server/routers/ImageRouter.kt
+++ b/zeapp/server/src/main/kotlin/de/berlindroid/zekompanion/server/routers/ImageRouter.kt
@@ -1,6 +1,6 @@
 package de.berlindroid.zekompanion.server.routers
 
-import de.berlindroid.zekompanion.BadgePayload
+import de.berlindroid.zekompanion.BadgePayload.*
 import de.berlindroid.zekompanion.base64
 import de.berlindroid.zekompanion.server.ext.ImageExt.toImage
 import de.berlindroid.zekompanion.server.ext.ImageExt.transform
@@ -30,10 +30,7 @@ fun Route.imageBin() =
         runCatching {
             val image = call.receiveNullable<ImageRequest>() ?: throw IllegalArgumentException("Payload is null")
 
-            val payload = BadgePayload(
-                debug = false,
-                type = "preview",
-                meta = "",
+            val payload = PreviewPayload(
                 payload = image.transform()
                     .toBinary()
                     .zipit()

--- a/zeapp/terminal/src/main/kotlin/de/berlindroid/zekompanion/terminal/Main.kt
+++ b/zeapp/terminal/src/main/kotlin/de/berlindroid/zekompanion/terminal/Main.kt
@@ -1,6 +1,5 @@
 package de.berlindroid.zekompanion.terminal
 
-import de.berlindroid.zekompanion.BadgePayload
 import de.berlindroid.zekompanion.base64
 import de.berlindroid.zekompanion.buildBadgeManager
 import de.berlindroid.zekompanion.ditherFloydSteinberg
@@ -14,6 +13,7 @@ import de.berlindroid.zekompanion.toBinary
 import de.berlindroid.zekompanion.zipit
 import de.berlindroid.zekompanion.BADGE_WIDTH
 import de.berlindroid.zekompanion.BADGE_HEIGHT
+import de.berlindroid.zekompanion.BadgePayload.*
 import kotlinx.coroutines.runBlocking
 import java.awt.image.BufferedImage
 import java.awt.image.BufferedImage.TYPE_INT_RGB
@@ -232,10 +232,8 @@ private fun resizeFluidImageCallback(size: String?): IntBuffer.(width: Int, heig
 
 
 private fun storeBufferOntoBadge(filename: String): IntBuffer.(width: Int, height: Int) -> IntBuffer = { _, _ ->
-    val payload = BadgePayload(
-        debug = false,
-        type = "store",
-        meta = filename,
+    val payload = StorePayload(
+        filename = filename,
         payload = toBinary().zipit().base64(),
     )
 
@@ -282,7 +280,7 @@ private fun rawCommand(
     command: String, meta: String = "", payload: String = "",
     resultTransformer: (result: Result<String>) -> String = ::defaultTransformer,
 ) {
-    val badgePayload = BadgePayload(
+    val badgePayload = RawPayload(
         debug = false,
         type = command,
         meta = meta,
@@ -316,11 +314,8 @@ private fun rawCommand(
 }
 
 private fun deleteStoredImageOnBadge(filename: String?): StorageOperation = {
-    val payload = BadgePayload(
-        debug = false,
-        type = "delete",
-        meta = filename ?: "",
-        payload = "",
+    val payload = DeletePayload(
+        filename = filename ?: ""
     )
 
     runBlocking {
@@ -340,10 +335,7 @@ private fun deleteStoredImageOnBadge(filename: String?): StorageOperation = {
 }
 
 private fun previewImageOnBadge(): IntBuffer.(width: Int, height: Int) -> IntBuffer = { _, _ ->
-    val payload = BadgePayload(
-        debug = false,
-        type = "preview",
-        meta = "",
+    val payload = PreviewPayload(
         payload = toBinary().zipit().base64(),
     )
 


### PR DESCRIPTION
https://github.com/gdg-berlin-android/ZeBadge/issues/261

## Summary

Make `BadgePayload` a sealed class with subclasses for each command.

## How It Was Tested

Just checked that the android app compiles and runs on an API Level 34 emulator 🙈.