### PR TITLE
Fix crash and show contributors from GitHub

### DIFF
--- a/zeapp/android/build.gradle.kts
+++ b/zeapp/android/build.gradle.kts
@@ -1,6 +1,4 @@
-import org.jetbrains.kotlin.incremental.createDirectory
 import org.jlleitschuh.gradle.ktlint.reporter.ReporterType
-import java.lang.ProcessBuilder.Redirect
 
 plugins {
     alias(libs.plugins.android.application)
@@ -232,33 +230,6 @@ kapt {
 tasks.withType(org.jetbrains.kotlin.gradle.tasks.KaptGenerateStubs::class).configureEach {
     kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
 }
-
-tasks.create("generateContributorsAsset") {
-    val command = "git shortlog -sne --all"
-    val process =
-        ProcessBuilder()
-            .command(command.split(" "))
-            .directory(rootProject.projectDir)
-            .redirectOutput(Redirect.PIPE)
-            .redirectError(Redirect.PIPE)
-            .start()
-    process.waitFor(60, TimeUnit.SECONDS)
-    val result = process.inputStream.bufferedReader().readText()
-
-    val contributors =
-        result
-            .lines()
-            .joinToString(separator = System.lineSeparator()) { it.substringAfter("\t") }
-
-    val assetDir =
-        layout.buildDirectory
-            .dir("generated/assets")
-            .get()
-            .asFile
-    assetDir.createDirectory()
-    File(assetDir, "test.txt").writeText(contributors)
-}
-tasks.getByName("build").dependsOn("generateContributorsAsset")
 
 licenseReport {
     generateHtmlReport = true

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeservices/ZeContributorsService.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeservices/ZeContributorsService.kt
@@ -1,21 +1,58 @@
 package de.berlindroid.zeapp.zeservices
 
-import android.content.Context
-import dagger.hilt.android.qualifiers.ApplicationContext
+import de.berlindroid.zeapp.zeui.zeabout.Contributor
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType.Companion.toMediaType
+import retrofit2.Retrofit
+import retrofit2.converter.kotlinx.serialization.asConverterFactory
+import retrofit2.http.GET
 import javax.inject.Inject
 
-class ZeContributorsService @Inject constructor(
-    @ApplicationContext private val context: Context,
-) {
-    fun contributors(): Flow<List<String>> = flow {
+class ZeContributorsService @Inject constructor() {
+    fun contributors(): Flow<List<Contributor>> = flow {
+
+        val contributors = githubApiService.getContributors()
+
         emit(
-            context.assets.open("test.txt")
-                .bufferedReader()
-                .readLines(),
+            contributors.map { Contributor(it.login, it.url, it.imageUrl, it.contributions) }
         )
     }.flowOn(Dispatchers.IO)
+}
+
+private val json = Json {
+    ignoreUnknownKeys = true
+}
+
+private val retrofit = Retrofit.Builder()
+    .baseUrl("https://api.github.com/repos/gdg-berlin-android/zebadge/")
+    .addConverterFactory(json.asConverterFactory("application/json".toMediaType()))
+    .build()
+
+private val githubApiService = retrofit.create(GithubApi::class.java)
+
+private interface GithubApi {
+
+    @Serializable
+    data class Contributor(
+        @SerialName(value = "login")
+        val login: String,
+
+        @SerialName(value = "contributions")
+        val contributions: Int,
+
+        @SerialName(value = "html_url")
+        val url: String,
+
+        @SerialName(value = "avatar_url")
+        val imageUrl: String,
+    )
+
+    @GET("contributors")
+    suspend fun getContributors(): List<Contributor>
 }

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zeabout/Contributor.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zeabout/Contributor.kt
@@ -1,0 +1,3 @@
+package de.berlindroid.zeapp.zeui.zeabout
+
+data class Contributor(val name: String, val url: String, val imageUrl: String, val contributions: Int)

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zeabout/ZeAboutScreen.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zeabout/ZeAboutScreen.kt
@@ -1,10 +1,7 @@
 package de.berlindroid.zeapp.zeui.zeabout
 
-import android.content.Intent
-import android.net.Uri
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -13,10 +10,8 @@ import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -25,14 +20,10 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
-import de.berlindroid.zeapp.R
-import de.berlindroid.zeapp.ZeDimen
 import de.berlindroid.zekompanion.getPlatform
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -41,9 +32,8 @@ fun ZeAbout(
     paddingValues: PaddingValues,
     vm: ZeAboutViewModel = hiltViewModel(),
 ) {
-    val lines by vm.lines.collectAsState()
+    val contributors by vm.lines.collectAsState()
 
-    val context = LocalContext.current
     Surface(
         modifier = Modifier
             .fillMaxSize()
@@ -64,7 +54,7 @@ fun ZeAbout(
                         .background(MaterialTheme.colorScheme.surface.copy(alpha = 0.9f)),
                 ) {
                     Text(
-                        text = "${lines.count()} contributors",
+                        text = "${contributors.count()} contributors",
                         modifier = Modifier.padding(8.dp),
                         style = MaterialTheme.typography.bodyMedium,
                         fontSize = 24.sp,
@@ -75,27 +65,16 @@ fun ZeAbout(
                     )
                 }
             }
-            items(lines) { line ->
+            items(contributors) { contributor ->
                 Row(
                     verticalAlignment = Alignment.CenterVertically,
                 ) {
-                    val email = line.substring(line.indexOf('<').plus(1), line.lastIndexOf('>')).trim()
                     Text(
-                        text = line.substring(0, line.indexOf('<')).trim(),
+                        text = contributor.name,
                         color = MaterialTheme.colorScheme.onSurface,
                         modifier = Modifier.padding(8.dp),
                         style = MaterialTheme.typography.bodyMedium,
                         fontSize = 18.sp,
-                    )
-                    Icon(
-                        painter = painterResource(id = R.drawable.email),
-                        contentDescription = "Send random page to badge",
-                        Modifier
-                            .size(20.dp, 20.dp)
-                            .clickable {
-                                val intent = Intent(Intent.ACTION_VIEW, Uri.parse("mailto:$email"))
-                                context.startActivity(intent)
-                            },
                     )
                 }
             }

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zeabout/ZeAboutViewModel.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zeabout/ZeAboutViewModel.kt
@@ -14,6 +14,6 @@ class ZeAboutViewModel @Inject constructor(
     contributorsService: ZeContributorsService,
 ):ViewModel(){
 
-    val lines: StateFlow<List<String>> = contributorsService.contributors()
+    val lines: StateFlow<List<Contributor>> = contributorsService.contributors()
         .stateIn(viewModelScope, SharingStarted.Lazily, initialValue = emptyList())
 }


### PR DESCRIPTION
## Summary

Fixing a crash when navigating to ZeAbout screen. Getting contributors from GitHub and showing their names.

## How It Was Tested

Did run the app.

## Screenshot/Gif

<details>

<summary>ZeAbout</summary>

![zeabout](https://github.com/gdg-berlin-android/ZeBadge/assets/1707189/38a07443-2fd4-4dff-bd37-c246ebf89347)


</details>