### PR TITLE
Fix: scrolling button not scroll to first/last item

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeFloatingScroller.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeFloatingScroller.kt
@@ -19,25 +19,20 @@ import androidx.compose.material3.Text as ZeText
 
 @Composable
 fun ZeFloatingScroller(
-    coroutineScope: CoroutineScope,
-    lazyListState: LazyListState,
-    scrollLength: Float,
+    modifier: Modifier = Modifier,
     text: String,
+    onClick: () -> Unit,
 ) {
     FloatingActionButton(
         containerColor = ZeBlack,
-        modifier = Modifier
+        modifier = modifier
             .padding(16.dp)
             .border(
                 width = 1.dp,
                 color = ZeWhite,
                 shape = RoundedCornerShape(16.dp),
             ),
-        onClick = {
-            coroutineScope.launch {
-                lazyListState.animateScrollBy(scrollLength)
-            }
-        },
+        onClick = onClick,
     ) {
         ZeText(
             text = text,

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeNavigationPad.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeNavigationPad.kt
@@ -1,10 +1,8 @@
 package de.berlindroid.zeapp.zeui
 
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
@@ -14,13 +12,13 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.launch
 
 @Composable
 fun ZeNavigationPad(
     lazyListState: LazyListState,
 ) {
     val coroutineScope = rememberCoroutineScope()
-    val scrollLength = 425f
     val topReached by remember { derivedStateOf { lazyListState.layoutInfo.visibleItemsInfo.firstOrNull()?.offset == 0 } }
     val bottomReached by remember {
         derivedStateOf {
@@ -36,11 +34,14 @@ fun ZeNavigationPad(
         horizontalAlignment = Alignment.End,
     ) {
         if (!topReached) {
-            ZeFloatingScroller(coroutineScope, lazyListState, -scrollLength, "↑")
+            ZeFloatingScroller(text = "↑") {
+                coroutineScope.launch { lazyListState.animateScrollToItem(0) }
+            }
         }
-        Spacer(modifier = Modifier.size(10.dp))
         if (!bottomReached) {
-            ZeFloatingScroller(coroutineScope, lazyListState, scrollLength, "↓")
+            ZeFloatingScroller(text = "↓") {
+                coroutineScope.launch { lazyListState.animateScrollToItem(lazyListState.layoutInfo.totalItemsCount - 1) }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
Fix [issue](https://github.com/gdg-berlin-android/ZeBadge/issues/230), click scroll button `up` and `down` will scroll to topmost and bottommost.
Also remove padding between up & down button to avoid slightly shifting down when button is updated from up to down.

## How It Was Tested

Manual testing.

## Screenshot/Gif

<!-- If applicable, show off the user facing changes. -->

<details>

<summary>Screenshot Name</summary>

Before | After
:--: | :--:
<video src="https://github.com/gdg-berlin-android/ZeBadge/assets/56693599/8655851b-2fce-4ad9-85b7-b736752548a7" width="300" />|<video src="https://github.com/gdg-berlin-android/ZeBadge/assets/56693599/83654ed4-058b-4ab6-9a8f-754de3bcf874" width="300" />

</details>