### PR TITLE
#352: Remind user to use a binary filter if the image is not binary

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeBinaryImageEditor.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeBinaryImageEditor.kt
@@ -34,6 +34,7 @@ import de.berlindroid.zeapp.R
 import de.berlindroid.zeapp.ZeDimen
 import de.berlindroid.zeapp.zebits.copy
 import de.berlindroid.zeapp.zebits.isBinary
+import de.berlindroid.zeapp.zeui.zetheme.ZeBlack
 import de.berlindroid.zeapp.zeui.zetheme.ZeGrey
 import de.berlindroid.zekompanion.BADGE_HEIGHT
 import de.berlindroid.zekompanion.BADGE_WIDTH
@@ -62,8 +63,6 @@ fun BinaryImageEditor(
 ) {
     var last by remember { mutableStateOf<Bitmap?>(null) }
 
-    val isImageBinary = remember { bitmap.isBinary() }
-
     Column {
         Image(
             modifier = Modifier
@@ -79,8 +78,11 @@ fun BinaryImageEditor(
             contentDescription = null,
         )
 
-        if (isImageBinary) {
-            Text(text = stringResource(id = R.string.remind_binary_image))
+        if (!bitmap.isBinary()) {
+            Text(
+                color = ZeBlack,
+                text = stringResource(id = R.string.remind_binary_image),
+            )
         }
 
         LazyRow(

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeBinaryImageEditor.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeBinaryImageEditor.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -32,6 +33,7 @@ import androidx.compose.ui.unit.dp
 import de.berlindroid.zeapp.R
 import de.berlindroid.zeapp.ZeDimen
 import de.berlindroid.zeapp.zebits.copy
+import de.berlindroid.zeapp.zebits.isBinary
 import de.berlindroid.zeapp.zeui.zetheme.ZeGrey
 import de.berlindroid.zekompanion.BADGE_HEIGHT
 import de.berlindroid.zekompanion.BADGE_WIDTH
@@ -59,6 +61,8 @@ fun BinaryImageEditor(
 ) {
     var last by remember { mutableStateOf<Bitmap?>(null) }
 
+    val isImageBinary = remember { bitmap.isBinary() }
+
     Column {
         Image(
             modifier = Modifier
@@ -73,6 +77,10 @@ fun BinaryImageEditor(
             contentScale = ContentScale.FillWidth,
             contentDescription = null,
         )
+
+        if (isImageBinary) {
+            Text(text = stringResource(id = R.string.remind_binary_image))
+        }
 
         LazyRow(
             modifier = Modifier

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeBinaryImageEditor.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/ZeBinaryImageEditor.kt
@@ -52,6 +52,7 @@ import java.nio.IntBuffer
  * @param bitmap the initial bitmap to be converted
  * @param bitmapUpdated update callback to be called when the bitmap is updated.
  */
+@Suppress("LongMethod")
 @Composable
 @Preview
 fun BinaryImageEditor(

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zevm/ZeBadgeViewModel.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zevm/ZeBadgeViewModel.kt
@@ -124,32 +124,33 @@ class ZeBadgeViewModel @Inject constructor(
             null
         } ?: return
 
+        val bitmap = configuration.bitmap
+        if (!bitmap.isBinary()) {
+            showMessage("Please create a binary image for page '${slot.name}'.")
+            return
+        }
+
         if (!badgeManager.isConnected()) {
             showMessage("Please connect a badge.")
             return
         }
 
-        val bitmap = configuration.bitmap
-        if (bitmap.isBinary()) {
-            viewModelScope.launch {
-                badgeManager.storePage(configuration.type.name, bitmap).fold(
-                    onSuccess = { storeResult ->
-                        delay(300) // serial stuff
-                        badgeManager.showPage(configuration.type.name).fold(
-                            onSuccess = { showResult ->
-                                showMessage(
-                                    // Hadouken¹
-                                    "${showResult + storeResult} bytes were sent.",
-                                )
-                            },
-                            onFailure = { showMessage("❗${it.message ?: "Unknown error"} ❗") },
-                        )
-                    },
-                    onFailure = { showMessage("❗${it.message ?: "Unknown error"} ❗") },
-                )
-            }
-        } else {
-            showMessage("Please create a binary image for page '${slot.name}'.")
+        viewModelScope.launch {
+            badgeManager.storePage(configuration.type.name, bitmap).fold(
+                onSuccess = { storeResult ->
+                    delay(300) // serial stuff
+                    badgeManager.showPage(configuration.type.name).fold(
+                        onSuccess = { showResult ->
+                            showMessage(
+                                // Hadouken¹
+                                "${showResult + storeResult} bytes were sent.",
+                            )
+                        },
+                        onFailure = { showMessage("❗${it.message ?: "Unknown error"} ❗") },
+                    )
+                },
+                onFailure = { showMessage("❗${it.message ?: "Unknown error"} ❗") },
+            )
         }
     }
 

--- a/zeapp/android/src/main/res/values/strings.xml
+++ b/zeapp/android/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="invert">Invert</string>
     <string name="static_tool">Static</string>
     <string name="ze_very_important" tools:ignore="MissingTranslation">Very Important</string>
+    <string name="remind_binary_image" tools:ignore="MissingTranslation">(This is a non-binary image. Please select a color filter below.)</string>
 
     <string name="generate">Generate</string>
     <string name="not_binary_image">Not a binary image. Make sure each pixel is either black or white.</string>


### PR DESCRIPTION
## Summary

Remedy for #352 

* Check for non-binary before trying to connect
* Show message to user to make image binary if the image is non-binary

## How It Was Tested

* I used the laptop from the booth, but there were issues connecting to my phone or emulators
* I eventually wait for the CI to build the dev app and download and test instead
* The feature is tested to be working

## Screenshot/Gif

https://github.com/gdg-berlin-android/ZeBadge/assets/34705943/98ac98b7-140c-4a09-bb42-a36003c6f4de
