### PR TITLE
[conflict]Add ZeDrawerItemData to host the drawer items and pass the items as List to ZeDrawerContent

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZeDrawerContent.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZeDrawerContent.kt
@@ -4,9 +4,6 @@ import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Info
-import androidx.compose.material.icons.filled.ThumbUp
 import androidx.compose.material3.DrawerDefaults
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
@@ -21,12 +18,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import de.berlindroid.zeapp.R
 import de.berlindroid.zeapp.zeui.zetheme.ZeBlack
 import de.berlindroid.zeapp.zeui.zetheme.ZeWhite
 
@@ -34,14 +29,9 @@ import de.berlindroid.zeapp.zeui.zetheme.ZeWhite
 @Preview
 internal fun ZeDrawerContent(
     drawerState: DrawerState = DrawerState(DrawerValue.Open),
-    onSaveAllClick: () -> Unit = {},
-    onGetStoredPages: () -> Unit = {},
-    onGotoReleaseClick: () -> Unit = {},
-    onGotoContributors: () -> Unit = {},
-    onGotoOpenSourceClick: () -> Unit = {},
-    onUpdateConfig: () -> Unit = {},
     onCloseDrawer: () -> Unit = {},
     onTitleClick: () -> Unit = {},
+    zeDrawerItems: List<ZeDrawerItemData> = listOf(),
 ) {
     @Composable
     fun NavDrawerItem(
@@ -107,78 +97,37 @@ internal fun ZeDrawerContent(
         }
 
         LazyColumn {
-            item {
-                NavDrawerItem(
-                    onClick = onSaveAllClick,
-                    painter = painterResource(id = R.drawable.save_all),
-                    text = stringResource(id = R.string.ze_navdrawer_save_all_pages),
-                )
-            }
+            items(zeDrawerItems.size) { index ->
+                when (val currentItem = zeDrawerItems[index]) {
+                    is ZeDrawerItemData.ItemWithText -> {
+                        if (currentItem.icon != null) {
+                            NavDrawerItem(
+                                onClick = currentItem.onClick,
+                                painter = painterResource(id = currentItem.icon),
+                                text = stringResource(id = currentItem.text),
+                            )
+                        } else if (currentItem.imageVector != null) {
+                            NavDrawerItem(
+                                onClick = currentItem.onClick,
+                                vector = currentItem.imageVector,
+                                text = stringResource(id = currentItem.text),
+                            )
+                        }
+                    }
 
-            item {
-                NavDrawerItem(
-                    text = stringResource(id = R.string.ze_navdrawer_update_config),
-                    vector = Icons.Default.ThumbUp,
-                    onClick = onUpdateConfig,
-                )
-            }
-
-            item {
-                NavDrawerItem(
-                    painter = painterResource(id = R.drawable.ic_random),
-                    text = stringResource(id = R.string.ze_navdrawer_send_random_page),
-                    onClick = onGetStoredPages,
-                )
-            }
-
-            item {
-                HorizontalDivider(
-                    thickness = 0.dp,
-                    color = MaterialTheme.colorScheme.background,
-                    modifier = Modifier.padding(
-                        start = 0.dp,
-                        end = 0.dp,
-                        top = 16.dp,
-                        bottom = 16.dp,
-                    ),
-                )
-            }
-
-            item {
-                NavDrawerItem(
-                    text = stringResource(id = R.string.ze_navdrawer_contributors),
-                    painter = rememberVectorPainter(Icons.Default.Info),
-                    onClick = onGotoContributors,
-                )
-            }
-
-            item {
-                NavDrawerItem(
-                    text = stringResource(id = R.string.ze_navdrawer_open_source),
-                    painter = painterResource(id = R.drawable.ic_open_source_initiative),
-                    onClick = onGotoOpenSourceClick,
-                )
-            }
-
-            item {
-                HorizontalDivider(
-                    thickness = 0.dp,
-                    color = MaterialTheme.colorScheme.background,
-                    modifier = Modifier.padding(
-                        start = 0.dp,
-                        end = 0.dp,
-                        top = 16.dp,
-                        bottom = 16.dp,
-                    ),
-                )
-            }
-
-            item {
-                NavDrawerItem(
-                    text = stringResource(id = R.string.ze_navdrawer_open_release_page),
-                    painter = painterResource(id = R.drawable.ic_update),
-                    onClick = onGotoReleaseClick,
-                )
+                    is ZeDrawerItemData.HorizontalDivider -> {
+                        HorizontalDivider(
+                            thickness = 0.dp,
+                            color = MaterialTheme.colorScheme.background,
+                            modifier = Modifier.padding(
+                                start = 0.dp,
+                                end = 0.dp,
+                                top = 16.dp,
+                                bottom = 16.dp,
+                            ),
+                        )
+                    }
+                }
             }
         }
     }

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZeDrawerItemData.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZeDrawerItemData.kt
@@ -1,0 +1,18 @@
+package de.berlindroid.zeapp.zeui.zehome
+
+import androidx.annotation.DrawableRes
+import androidx.annotation.StringRes
+import androidx.compose.ui.graphics.vector.ImageVector
+
+sealed class ZeDrawerItemData {
+
+    data class ItemWithText(
+        val onClick: () -> Unit,
+        @DrawableRes val icon: Int? = null,
+        val imageVector: ImageVector? = null,
+        @StringRes val text: Int,
+    ) : ZeDrawerItemData()
+
+    data object HorizontalDivider : ZeDrawerItemData()
+
+}

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZeDrawerItemData.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZeDrawerItemData.kt
@@ -14,5 +14,4 @@ sealed class ZeDrawerItemData {
     ) : ZeDrawerItemData()
 
     data object HorizontalDivider : ZeDrawerItemData()
-
 }

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZeScreen.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZeScreen.kt
@@ -4,6 +4,9 @@ import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.lazy.rememberLazyListState
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material.icons.filled.ThumbUp
 import androidx.compose.material3.DrawerValue
 import androidx.compose.material3.ModalNavigationDrawer
 import androidx.compose.material3.Scaffold
@@ -14,10 +17,12 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import de.berlindroid.zeapp.R
 import de.berlindroid.zeapp.ROUTE_ABOUT
 import de.berlindroid.zeapp.ROUTE_HOME
 import de.berlindroid.zeapp.ROUTE_OPENSOURCE
@@ -77,34 +82,18 @@ internal fun ZeScreen(vm: ZeBadgeViewModel, modifier: Modifier = Modifier) {
                 drawerContent = {
                     ZeDrawerContent(
                         drawerState,
-                        onGetStoredPages = vm::getStoredPages,
-                        onSaveAllClick = vm::saveAll,
-                        onGotoReleaseClick = goToReleases,
-                        onGotoContributors = {
-                            if (currentRoute == ROUTE_ABOUT) {
-                                navController.navigateUp()
-                            } else {
-                                navController.navigate(
-                                    ROUTE_ABOUT,
-                                )
-                            }
-                        },
-                        onGotoOpenSourceClick = {
-                            if (currentRoute == ROUTE_OPENSOURCE) {
-                                navController.navigateUp()
-                            } else {
-                                navController.navigate(
-                                    ROUTE_OPENSOURCE,
-                                )
-                            }
-                        },
-                        onUpdateConfig = vm::listConfiguration,
                         onCloseDrawer = {
                             scope.launch {
                                 drawerState.close()
                             }
                         },
                         onTitleClick = goToGithubPage,
+                        zeDrawerItems = getZeDrawerItems(
+                            zeBadgeViewModel = vm,
+                            currentRoute = currentRoute,
+                            navController = navController,
+                            goToReleases = goToReleases,
+                        ),
                     )
                 },
             ) {
@@ -147,3 +136,60 @@ internal fun ZeScreen(vm: ZeBadgeViewModel, modifier: Modifier = Modifier) {
         },
     )
 }
+
+private fun getZeDrawerItems(
+    zeBadgeViewModel: ZeBadgeViewModel,
+    currentRoute: String,
+    navController: NavHostController,
+    goToReleases: () -> Unit,
+): List<ZeDrawerItemData> = listOf(
+    ZeDrawerItemData.ItemWithText(
+        onClick = zeBadgeViewModel::saveAll,
+        icon = R.drawable.save_all,
+        text = R.string.ze_navdrawer_save_all_pages,
+    ),
+    ZeDrawerItemData.ItemWithText(
+        onClick = zeBadgeViewModel::listConfiguration,
+        imageVector = Icons.Default.ThumbUp,
+        text = R.string.ze_navdrawer_update_config,
+    ),
+    ZeDrawerItemData.ItemWithText(
+        onClick = zeBadgeViewModel::listConfiguration,
+        icon = R.drawable.ic_random,
+        text = R.string.ze_navdrawer_send_random_page,
+    ),
+    ZeDrawerItemData.HorizontalDivider,
+    ZeDrawerItemData.ItemWithText(
+        onClick = {
+            if (currentRoute == ROUTE_ABOUT) {
+                navController.navigateUp()
+            } else {
+                navController.navigate(
+                    ROUTE_ABOUT,
+                )
+            }
+        },
+        imageVector = Icons.Default.Info,
+        text = R.string.ze_navdrawer_contributors,
+    ),
+    ZeDrawerItemData.ItemWithText(
+        onClick = {
+            if (currentRoute == ROUTE_OPENSOURCE) {
+                navController.navigateUp()
+            } else {
+                navController.navigate(
+                    ROUTE_OPENSOURCE,
+                )
+            }
+        },
+        icon = R.drawable.ic_open_source_initiative,
+        text = R.string.ze_navdrawer_open_source,
+    ),
+    ZeDrawerItemData.ItemWithText(
+        onClick = goToReleases,
+        icon = R.drawable.ic_update,
+        text = R.string.ze_navdrawer_open_release_page,
+
+        ),
+    ZeDrawerItemData.HorizontalDivider,
+)

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZeScreen.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZeScreen.kt
@@ -195,8 +195,7 @@ private fun getZeDrawerItems(
         onClick = goToReleases,
         icon = R.drawable.ic_update,
         text = R.string.ze_navdrawer_open_release_page,
-
-        ),
+    ),
     ZeDrawerItemData.HorizontalDivider,
 )
 


### PR DESCRIPTION
## Summary

Items are repeated inside ZeDrawerContent, so we pass them as List of ZeDrawerItemData to avoid duplications. 