### PR TITLE
Create emulator drawing modifier.

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZeScreen.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZeScreen.kt
@@ -3,6 +3,7 @@ package de.berlindroid.zeapp.zeui.zehome
 import android.content.Intent
 import android.net.Uri
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.DrawerValue
@@ -15,6 +16,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState


### PR DESCRIPTION
## Summary

This allows to draw on top of the emulated badge.
The drawing is saved onto a bitmap and could be:
- saved to the list
- sent to badge
- returned to the list

More work is needed later for feature completeness.

## How It Was Tested

Emulator only

## Screenshot/Gif

![image](https://github.com/gdg-berlin-android/ZeBadge/assets/2651842/c2ea4945-9948-4993-8f09-6834a17d7558)


<details>

<summary>Screenshot Name</summary>

<!-- file here -->

</details>