### PR TITLE
[app] Optimise gradle dependency resolution by adding filters on 'google' and 'jitpack.io' repositories

### DIFF
--- a/zeapp/settings.gradle.kts
+++ b/zeapp/settings.gradle.kts
@@ -17,10 +17,14 @@ dependencyResolutionManagement {
                 includeGroupByRegex("com\\.android\\..*")
             }
         }
-        mavenCentral()
         maven {
             setUrl("https://jitpack.io")
+            content {
+                includeGroup("com.github.mik3y")
+                includeGroup("com.github.Commit451.coil-transformations")
+            }
         }
+        mavenCentral()
     }
 }
 

--- a/zeapp/settings.gradle.kts
+++ b/zeapp/settings.gradle.kts
@@ -11,7 +11,12 @@ pluginManagement {
 
 dependencyResolutionManagement {
     repositories {
-        google()
+        google {
+            content {
+                includeGroupByRegex("androidx\\..*")
+                includeGroupByRegex("com\\.android\\..*")
+            }
+        }
         mavenCentral()
         maven {
             setUrl("https://jitpack.io")


### PR DESCRIPTION
## Summary

Configures the artefact groups for 'google' and 'jitpack.io' repositories so that dependency resolution would be more efficient, skipping unnecessary GET requests to these repositories.

## How It Was Tested

Built app successfully with optimised settings:

<img width="258" alt="gdg" src="https://github.com/gdg-berlin-android/ZeBadge/assets/56091100/36bc02ec-1635-4d13-899e-17e02f72c5d9">

## Screenshot/Gif

N/A (no user-facing changes)

</details>