### PR TITLE
chore: replace Kapt with KSP

### DIFF
--- a/zeapp/android/build.gradle.kts
+++ b/zeapp/android/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     alias(libs.plugins.ktlint.gradle)
     alias(libs.plugins.detekt.gradle)
     alias(libs.plugins.dagger.hilt)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.serialization)
     alias(libs.plugins.license.report.gradle)
     alias(libs.plugins.baselineprofile)
@@ -206,7 +206,7 @@ dependencies {
 
     androidTestImplementation(libs.testComposeJunit)
     debugImplementation(libs.testComposeManifest)
-    kapt(libs.dagger.hilt.compiler)
+    ksp(libs.dagger.hilt.compiler)
     baselineProfile(projects.benchmark)
 }
 
@@ -225,14 +225,6 @@ ktlint {
     filter {
         exclude("**/generated/**")
     }
-}
-
-kapt {
-    correctErrorTypes = true
-}
-
-tasks.withType(org.jetbrains.kotlin.gradle.tasks.KaptGenerateStubs::class).configureEach {
-    kotlinOptions.jvmTarget = JavaVersion.VERSION_1_8.toString()
 }
 
 licenseReport {

--- a/zeapp/build.gradle.kts
+++ b/zeapp/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     alias(libs.plugins.android.test) apply false
     alias(libs.plugins.kotlin.android) apply false
     alias(libs.plugins.kotlin.multiplatform) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.detekt.gradle) apply false
     alias(libs.plugins.dagger.hilt) apply false

--- a/zeapp/gradle/libs.versions.toml
+++ b/zeapp/gradle/libs.versions.toml
@@ -20,6 +20,7 @@ jSerialComm = "2.10.3"
 kotlin = "1.9.24"
 kotlinx-coroutines-core = "1.8.1"
 kotlinxSerializationJson = "1.6.3"
+ksp = "1.9.24-1.0.20"
 ktlint-gradle = "11.6.1"
 license-report-gradle = "0.9.3"
 material3-wsc = "1.2.1"
@@ -58,7 +59,7 @@ baselineprofile = { id = "androidx.baselineprofile", version.ref = "benchmark" }
 dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "dagger-hilt" }
 detekt-gradle = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt-gradle" }
 kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 ktlint-gradle = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint-gradle" }
 license-report-gradle = { id = "com.jaredsburrows.license", version.ref = "license-report-gradle" }
 aboutlibraries-gradle = { id = "com.mikepenz.aboutlibraries.plugin", version.ref = "aboutlibraries" }


### PR DESCRIPTION
## Summary

Use KSP instead of Kapt to avoid generating Java stubs for Dagger Hilt processing and build faster.

## How It Was Tested

The Android app builds and runs successfully.