### PR TITLE
[Enhancement] Enabling floating Info bar

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/InfoBar.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/InfoBar.kt
@@ -34,21 +34,21 @@ import de.berlindroid.zeapp.zeui.zetheme.ZeWhite
 @Composable
 @Preview
 internal fun InfoBar(
+    modifier: Modifier = Modifier,
     message: String = stringResource(id = R.string.ze_very_important),
     progress: Float = 0.5f,
     copyMoreToClipboard: (() -> Unit) = {},
 ) {
     Card(
-        modifier =
-            Modifier
-                .padding(horizontal = ZeDimen.One, vertical = ZeDimen.One)
-                .background(ZeCarmine, RoundedCornerShape(ZeDimen.One))
-                .zIndex(10.0f),
+        modifier = modifier
+            .padding(horizontal = ZeDimen.One, vertical = ZeDimen.One)
+            .background(ZeCarmine, RoundedCornerShape(ZeDimen.One))
+            .zIndex(10.0f),
         colors =
-            CardDefaults.cardColors(
-                containerColor = ZeCarmine,
-                contentColor = ZeWhite,
-            ),
+        CardDefaults.cardColors(
+            containerColor = ZeCarmine,
+            contentColor = ZeWhite,
+        ),
     ) {
         Row(
             modifier = Modifier.padding(horizontal = ZeDimen.Two, vertical = ZeDimen.One),
@@ -65,9 +65,9 @@ internal fun InfoBar(
             IconButton(onClick = copyMoreToClipboard) {
                 Icon(
                     painter =
-                        painterResource(
-                            id = R.drawable.copy_clipboard,
-                        ),
+                    painterResource(
+                        id = R.drawable.copy_clipboard,
+                    ),
                     contentDescription = "Copy info bar message",
                 )
             }
@@ -76,9 +76,9 @@ internal fun InfoBar(
         LinearProgressIndicator(
             progress = { progress },
             modifier =
-                Modifier
-                    .fillMaxWidth()
-                    .padding(start = 12.dp, end = 12.dp, top = 0.dp, bottom = 4.dp),
+            Modifier
+                .fillMaxWidth()
+                .padding(start = 12.dp, end = 12.dp, top = 0.dp, bottom = 4.dp),
             color = ZeBlack,
             trackColor = ZeWhite,
             strokeCap = StrokeCap.Round,

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/InfoBar.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/InfoBar.kt
@@ -40,15 +40,16 @@ internal fun InfoBar(
     copyMoreToClipboard: (() -> Unit) = {},
 ) {
     Card(
-        modifier = modifier
-            .padding(horizontal = ZeDimen.One, vertical = ZeDimen.One)
-            .background(ZeCarmine, RoundedCornerShape(ZeDimen.One))
-            .zIndex(10.0f),
+        modifier =
+            modifier
+                .padding(horizontal = ZeDimen.One, vertical = ZeDimen.One)
+                .background(ZeCarmine, RoundedCornerShape(ZeDimen.One))
+                .zIndex(10.0f),
         colors =
-        CardDefaults.cardColors(
-            containerColor = ZeCarmine,
-            contentColor = ZeWhite,
-        ),
+            CardDefaults.cardColors(
+                containerColor = ZeCarmine,
+                contentColor = ZeWhite,
+            ),
     ) {
         Row(
             modifier = Modifier.padding(horizontal = ZeDimen.Two, vertical = ZeDimen.One),
@@ -65,9 +66,9 @@ internal fun InfoBar(
             IconButton(onClick = copyMoreToClipboard) {
                 Icon(
                     painter =
-                    painterResource(
-                        id = R.drawable.copy_clipboard,
-                    ),
+                        painterResource(
+                            id = R.drawable.copy_clipboard,
+                        ),
                     contentDescription = "Copy info bar message",
                 )
             }
@@ -76,9 +77,9 @@ internal fun InfoBar(
         LinearProgressIndicator(
             progress = { progress },
             modifier =
-            Modifier
-                .fillMaxWidth()
-                .padding(start = 12.dp, end = 12.dp, top = 0.dp, bottom = 4.dp),
+                Modifier
+                    .fillMaxWidth()
+                    .padding(start = 12.dp, end = 12.dp, top = 0.dp, bottom = 4.dp),
             color = ZeBlack,
             trackColor = ZeWhite,
             strokeCap = StrokeCap.Round,

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZePages.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZePages.kt
@@ -112,11 +112,11 @@ private fun ZePagesLazyList(
         state = lazyListState,
         modifier = modifier,
         contentPadding =
-        PaddingValues(
-            start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
-            end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
-            bottom = paddingValues.calculateBottomPadding(),
-        ),
+            PaddingValues(
+                start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
+                end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+                bottom = paddingValues.calculateBottomPadding(),
+            ),
     ) {
         items(
             slots.keys.toList(),
@@ -136,17 +136,17 @@ private fun ZePagesLazyList(
                 name = slot::class.simpleName ?: "WTF",
                 bitmap = slotToBitmap(slot),
                 customizeThisPage =
-                if (slot.isSponsor) {
-                    { customizeSponsorSlot(slot) }
-                } else {
-                    { customizeSlot(slot) }
-                },
+                    if (slot.isSponsor) {
+                        { customizeSponsorSlot(slot) }
+                    } else {
+                        { customizeSlot(slot) }
+                    },
                 resetThisPage =
-                if (slot.isSponsor) {
-                    null
-                } else {
-                    { resetSlot(slot) }
-                },
+                    if (slot.isSponsor) {
+                        null
+                    } else {
+                        { resetSlot(slot) }
+                    },
                 sendToDevice = {
                     sendPageToBadgeAndDisplay(slot)
                 },

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZePages.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeui/zehome/ZePages.kt
@@ -1,8 +1,8 @@
 package de.berlindroid.zeapp.zeui.zehome
 
+import android.graphics.Bitmap
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -14,7 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
@@ -22,21 +21,23 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.unit.LayoutDirection
 import de.berlindroid.zeapp.ZeDimen
+import de.berlindroid.zeapp.zemodels.ZeConfiguration
+import de.berlindroid.zeapp.zemodels.ZeSlot
 import de.berlindroid.zeapp.zevm.ZeBadgeViewModel
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 internal fun ZePages(
     paddingValues: PaddingValues,
     vm: ZeBadgeViewModel,
     lazyListState: LazyListState,
 ) {
-    Surface(
+    Box(
         modifier = Modifier.fillMaxSize(),
     ) {
         val uiState by vm.uiState.collectAsState() // should be replace with 'collectAsStateWithLifecycle'
@@ -47,7 +48,6 @@ internal fun ZePages(
         val templateChooser = uiState.currentTemplateChooser
         val message = uiState.message
         val messageProgress = uiState.messageProgress
-        val slots = uiState.slots
         val badgeConfiguration = uiState.currentBadgeConfig
 
         if (isKeyboardVisible && editor == null && templateChooser == null) {
@@ -73,59 +73,86 @@ internal fun ZePages(
             TemplateChooserDialog(vm, templateChooser, modifier = Modifier.padding(paddingValues))
         }
 
-        LazyColumn(
-            state = lazyListState,
-            modifier =
-                Modifier
-                    .padding(top = paddingValues.calculateTopPadding()),
-            contentPadding =
-                PaddingValues(
-                    start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
-                    end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
-                    bottom = paddingValues.calculateBottomPadding(),
-                ),
-        ) {
-            if (message.isNotEmpty()) {
-                stickyHeader {
-                    InfoBar(message, messageProgress, vm::copyInfoToClipboard)
-                }
-            }
-            items(
-                slots.keys.toList(),
-            ) { slot ->
-                var isVisible by remember { mutableStateOf(false) }
-                val alpha: Float by animateFloatAsState(
-                    targetValue = if (isVisible) 1f else 0f,
-                    label = "alpha",
-                    animationSpec = tween(durationMillis = 750),
-                )
-                LaunchedEffect(slot) {
-                    isVisible = true
-                }
+        ZePagesLazyList(
+            modifier = Modifier.padding(top = paddingValues.calculateTopPadding()),
+            paddingValues = paddingValues,
+            lazyListState = lazyListState,
+            slots = uiState.slots,
+            sendPageToBadgeAndDisplay = vm::sendPageToBadgeAndDisplay,
+            slotToBitmap = vm::slotToBitmap,
+            customizeSlot = vm::customizeSlot,
+            customizeSponsorSlot = vm::customizeSponsorSlot,
+            resetSlot = vm::resetSlot,
+        )
 
-                PagePreview(
-                    modifier = Modifier.graphicsLayer { this.alpha = alpha },
-                    name = slot::class.simpleName ?: "WTF",
-                    bitmap = vm.slotToBitmap(slot),
-                    customizeThisPage =
-                        if (slot.isSponsor) {
-                            { vm.customizeSponsorSlot(slot) }
-                        } else {
-                            { vm.customizeSlot(slot) }
-                        },
-                    resetThisPage =
-                        if (slot.isSponsor) {
-                            null
-                        } else {
-                            { vm.resetSlot(slot) }
-                        },
-                    sendToDevice = {
-                        vm.sendPageToBadgeAndDisplay(slot)
-                    },
-                )
+        if (message.isNotEmpty()) {
+            InfoBar(
+                modifier = Modifier.align(Alignment.BottomCenter),
+                message = message,
+                progress = messageProgress,
+                copyMoreToClipboard = vm::copyInfoToClipboard,
+            )
+        }
+    }
+}
 
-                Spacer(modifier = Modifier.height(ZeDimen.One))
+@Composable
+private fun ZePagesLazyList(
+    paddingValues: PaddingValues,
+    lazyListState: LazyListState,
+    slots: Map<ZeSlot, ZeConfiguration>,
+    sendPageToBadgeAndDisplay: (ZeSlot) -> Unit,
+    slotToBitmap: (ZeSlot) -> Bitmap,
+    customizeSponsorSlot: (ZeSlot) -> Unit,
+    customizeSlot: (ZeSlot) -> Unit,
+    resetSlot: (ZeSlot) -> Unit,
+    modifier: Modifier = Modifier,
+) {
+    LazyColumn(
+        state = lazyListState,
+        modifier = modifier,
+        contentPadding =
+        PaddingValues(
+            start = paddingValues.calculateStartPadding(LayoutDirection.Ltr),
+            end = paddingValues.calculateEndPadding(LayoutDirection.Ltr),
+            bottom = paddingValues.calculateBottomPadding(),
+        ),
+    ) {
+        items(
+            slots.keys.toList(),
+        ) { slot ->
+            var isVisible by remember { mutableStateOf(false) }
+            val alpha: Float by animateFloatAsState(
+                targetValue = if (isVisible) 1f else 0f,
+                label = "alpha",
+                animationSpec = tween(durationMillis = 750),
+            )
+            LaunchedEffect(slot) {
+                isVisible = true
             }
+
+            PagePreview(
+                modifier = Modifier.graphicsLayer { this.alpha = alpha },
+                name = slot::class.simpleName ?: "WTF",
+                bitmap = slotToBitmap(slot),
+                customizeThisPage =
+                if (slot.isSponsor) {
+                    { customizeSponsorSlot(slot) }
+                } else {
+                    { customizeSlot(slot) }
+                },
+                resetThisPage =
+                if (slot.isSponsor) {
+                    null
+                } else {
+                    { resetSlot(slot) }
+                },
+                sendToDevice = {
+                    sendPageToBadgeAndDisplay(slot)
+                },
+            )
+
+            Spacer(modifier = Modifier.height(ZeDimen.One))
         }
     }
 }


### PR DESCRIPTION
## Summary
Enabling floating Info bar to avoid list auto scrolling to the top

Solves https://github.com/gdg-berlin-android/ZeBadge/issues/391

<!--Provide a summary of this Pull Request. -->

## How It Was Tested

<!-- Explain how you tested this change before merging. -->
Manually tested according to the videos.
1. Tap to edit a badge;
2. Input an invalid data;
3. Check if the infobar is shown at the bottom of the screen.

## Screenshot/Gif
| Before | After |
| ------ | ------ |
| <video src=https://github.com/user-attachments/assets/fe0d2df1-8415-4c86-9dd7-181ed6a347b6 /> | <video src= https://github.com/user-attachments/assets/808e2dfa-1ba7-4f44-aa60-4083c0b1b5e2 /> |


<!-- If applicable, show off the user facing changes. -->

<details>

<summary>Screenshot Name</summary>

<!-- file here -->

</details>