### PR TITLE
(ref + fix): Moving ZeSlotConfiguration persistence logic to a repository

### DIFF
--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zerepositories/ZeSlotRepository.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zerepositories/ZeSlotRepository.kt
@@ -30,264 +30,276 @@ import javax.inject.Inject
  * It provides easy access methods to
  * [getSlotConfiguration], [saveSlotConfiguration], [removeSlotConfiguration], [getDefaultSlotConfiguration] and [getInitialSlots]
  */
-class ZeSlotRepository @Inject constructor(
-    private val zePreferencesService: ZePreferencesService,
-    private val imageProviderService: ZeImageProviderService,
-) {
-    // Constants
-    private companion object {
-        const val TYPE_KEY = "type"
-        const val IMAGE_KEY = "bitmap"
-    }
-
-    suspend fun getSlotConfiguration(slot: ZeSlot): ZeConfiguration? {
-        return zePreferencesService.dataStore.data.map { preferences ->
-
-            val type = ZeBadgeType.getOrNull(preferences[slot.preferencesKey(TYPE_KEY)].orEmpty())
-            val bitmap =
-                preferences[slot.preferencesKey(IMAGE_KEY)]
-                    ?.debase64()
-                    ?.toBitmap(BADGE_WIDTH, BADGE_HEIGHT)
-                    ?: return@map null
-
-            return@map getSlotConfigurationByType(
-                slot = slot,
-                type = type,
-                bitmap = bitmap,
-                preferences = preferences,
-            )
-        }.firstOrNull()
-    }
-
-    suspend fun saveSlotConfiguration(slot: ZeSlot, config: ZeConfiguration) {
-        zePreferencesService.dataStore.edit { preferences ->
-            preferences[slot.preferencesKey(TYPE_KEY)] = config.type.rawValue
-            preferences[slot.preferencesKey(IMAGE_KEY)] = config.bitmap.pixelBuffer().toBinary().base64()
-
-            saveSlotConfigurationByConfig(
-                slot = slot,
-                config = config,
-                preferences = preferences,
-            )
-        }
-    }
-
-    suspend fun removeSlotConfiguration(slot: ZeSlot) {
-        zePreferencesService.dataStore.edit { mutablePreferences ->
-            // Getting all related information about the slot config.
-            val slotRelatedKeys = mutablePreferences.asMap().keys.filter {
-                it.name.contains(slot.preferencesKeyPrefix())
-            }
-
-            // Deleting each key that refers to that slot config.
-            slotRelatedKeys.forEach { mutablePreferences.remove(it) }
-        }
-    }
-
-    fun getDefaultSlotConfiguration(slot: ZeSlot): ZeConfiguration = when (slot) {
-        is ZeSlot.Name ->
-            ZeConfiguration.Name(
-                null,
-                null,
-                imageProviderService.getInitialNameBitmap(),
-            )
-
-        is ZeSlot.FirstSponsor -> ZeConfiguration.Picture(R.drawable.page_google.toBitmap())
-        is ZeSlot.FirstCustom -> ZeConfiguration.Picture(R.drawable.soon.toBitmap())
-        is ZeSlot.SecondCustom -> ZeConfiguration.Picture(R.drawable.soon.toBitmap())
-        ZeSlot.QRCode ->
-            ZeConfiguration.QRCode(
-                title = "",
-                text = "",
-                url = "",
-                isVcard = false,
-                phone = "",
-                email = "",
-                bitmap = R.drawable.qrpage_preview.toBitmap(),
-            )
-
-        ZeSlot.Weather ->
-            ZeConfiguration.Weather(
-                LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE),
-                "22C",
-                R.drawable.soon.toBitmap(),
-            )
-
-        is ZeSlot.Quote ->
-            ZeConfiguration.Quote(
-                "Test",
-                "Author",
-                R.drawable.page_quote_sample.toBitmap(),
-            )
-
-        ZeSlot.BarCode ->
-            ZeConfiguration.BarCode(
-                "Your title for barcode",
-                "",
-                R.drawable.soon.toBitmap(),
-            )
-
-        ZeSlot.Add ->
-            ZeConfiguration.Name(
-                null,
-                null,
-                imageProviderService.provideImageBitmap(R.drawable.add),
-            )
-
-        ZeSlot.Camera ->
-            ZeConfiguration.Camera(
-                imageProviderService.provideImageBitmap(R.drawable.soon),
-            )
-    }
-
-    fun getInitialSlots(): List<ZeSlot> = listOf(
-        ZeSlot.Name,
-        ZeSlot.FirstSponsor,
-        ZeSlot.Camera,
-        ZeSlot.Add,
-    )
-
-    // region private implementation methods
-    private fun getSlotConfigurationByType(
-        slot: ZeSlot,
-        type: ZeBadgeType?,
-        bitmap: Bitmap,
-        preferences: Preferences,
-    ) = when (type) {
-        ZeBadgeType.NAME -> {
-            ZeConfiguration.Name(
-                name = preferences.slotFieldValue(slot, "name"),
-                contact = preferences.slotFieldValue(slot, "contact"),
-                bitmap = bitmap,
-            )
-        }
-
-        ZeBadgeType.CUSTOM_PICTURE -> ZeConfiguration.Picture(bitmap)
-
-        ZeBadgeType.IMAGE_GEN ->
-            ZeConfiguration.ImageGen(
-                prompt = preferences.slotFieldValue(slot, "prompt"),
-                bitmap = bitmap,
-            )
-
-        ZeBadgeType.GEOFENCE_SCHEDULE -> ZeConfiguration.Schedule(bitmap)
-
-        ZeBadgeType.UPCOMING_WEATHER ->
-            ZeConfiguration.Weather(
-                date = preferences.slotFieldValue(slot, "weather_date"),
-                temperature = preferences.slotFieldValue(slot, "weather_temperature"),
-                bitmap,
-            )
-
-        ZeBadgeType.QR_CODE ->
-            ZeConfiguration.QRCode(
-                title = preferences.slotFieldValue(slot, "qr_title"),
-                url = preferences.slotFieldValue(slot, "url"),
-                text = preferences.slotFieldValue(slot, "qr_text"),
-                isVcard = preferences.slotFieldValue(slot, "qr_is_vcard").toBoolean(),
-                phone = preferences.slotFieldValue(slot, "qr_phone"),
-                email = preferences.slotFieldValue(slot, "qr_email"),
-                bitmap = bitmap,
-            )
-
-        ZeBadgeType.PHRASE ->
-            ZeConfiguration.CustomPhrase(
-                phrase = preferences.slotFieldValue(slot, "random_phrase"),
-                bitmap = bitmap,
-            )
-
-        ZeBadgeType.BARCODE_TAG ->
-            ZeConfiguration.BarCode(
-                title = preferences.slotFieldValue(slot, "barcode_title"),
-                bitmap = bitmap,
-                url = preferences.slotFieldValue(slot, "url"),
-            )
-
-        ZeBadgeType.RANDOM_QUOTE ->
-            ZeConfiguration.Quote(
-                message = preferences.slotFieldValue(slot, "quote_message"),
-                author = preferences.slotFieldValue(slot, "quote_author"),
-                bitmap = bitmap,
-            )
-
-        ZeBadgeType.CAMERA -> ZeConfiguration.Camera(bitmap)
-
-        else -> {
-            Timber.e("Slot from Prefs: Cannot find $type slot in preferences.")
-            null
-        }
-    }
-
-    private fun saveSlotConfigurationByConfig(
-        slot: ZeSlot,
-        config: ZeConfiguration,
-        preferences: MutablePreferences,
+class ZeSlotRepository
+    @Inject
+    constructor(
+        private val zePreferencesService: ZePreferencesService,
+        private val imageProviderService: ZeImageProviderService,
     ) {
-        when (config) {
-            is ZeConfiguration.Name -> {
-                preferences[slot.preferencesKey("name")] = config.name.orEmpty()
-                preferences[slot.preferencesKey("contact")] = config.contact.orEmpty()
-            }
+        // Constants
+        private companion object {
+            const val TYPE_KEY = "type"
+            const val IMAGE_KEY = "bitmap"
+        }
 
-            is ZeConfiguration.ImageGen -> {
-                preferences[slot.preferencesKey("prompt")] = config.prompt
-            }
+        suspend fun getSlotConfiguration(slot: ZeSlot): ZeConfiguration? {
+            return zePreferencesService.dataStore.data.map { preferences ->
 
-            is ZeConfiguration.Picture -> {
-                // Nothing more to configure
-            }
+                val type = ZeBadgeType.getOrNull(preferences[slot.preferencesKey(TYPE_KEY)].orEmpty())
+                val bitmap =
+                    preferences[slot.preferencesKey(IMAGE_KEY)]
+                        ?.debase64()
+                        ?.toBitmap(BADGE_WIDTH, BADGE_HEIGHT)
+                        ?: return@map null
 
-            is ZeConfiguration.Schedule -> {
-                // TODO: Save schedule
-            }
+                return@map getSlotConfigurationByType(
+                    slot = slot,
+                    type = type,
+                    bitmap = bitmap,
+                    preferences = preferences,
+                )
+            }.firstOrNull()
+        }
 
-            is ZeConfiguration.Weather -> {
-                preferences[slot.preferencesKey("weather_date")] = config.date
-                preferences[slot.preferencesKey("weather_temperature")] = config.temperature
-            }
+        suspend fun saveSlotConfiguration(
+            slot: ZeSlot,
+            config: ZeConfiguration,
+        ) {
+            zePreferencesService.dataStore.edit { preferences ->
+                preferences[slot.preferencesKey(TYPE_KEY)] = config.type.rawValue
+                preferences[slot.preferencesKey(IMAGE_KEY)] = config.bitmap.pixelBuffer().toBinary().base64()
 
-            is ZeConfiguration.QRCode -> {
-                preferences[slot.preferencesKey("qr_title")] = config.title
-                preferences[slot.preferencesKey("url")] = config.url
-                preferences[slot.preferencesKey("qr_text")] = config.text
-                preferences[slot.preferencesKey("qr_phone")] = config.phone
-                preferences[slot.preferencesKey("qr_email")] = config.email
-                preferences[slot.preferencesKey("qr_is_vcard")] = config.isVcard.toString()
-            }
-
-            is ZeConfiguration.Camera,
-            is ZeConfiguration.Kodee,
-            -> Unit
-
-            is ZeConfiguration.ImageDraw -> {
-                // Nothing more to configure
-            }
-
-            is ZeConfiguration.Quote -> {
-                preferences[slot.preferencesKey("quote_author")] = config.author
-                preferences[slot.preferencesKey("quote_message")] = config.message
-            }
-
-            is ZeConfiguration.BarCode -> {
-                preferences[slot.preferencesKey("barcode_title")] = config.title
-                preferences[slot.preferencesKey("url")] = config.url
-            }
-
-            is ZeConfiguration.CustomPhrase -> {
-                preferences[slot.preferencesKey("random_phrase")] = config.phrase
+                saveSlotConfigurationByConfig(
+                    slot = slot,
+                    config = config,
+                    preferences = preferences,
+                )
             }
         }
+
+        suspend fun removeSlotConfiguration(slot: ZeSlot) {
+            zePreferencesService.dataStore.edit { mutablePreferences ->
+                // Getting all related information about the slot config.
+                val slotRelatedKeys =
+                    mutablePreferences.asMap().keys.filter {
+                        it.name.contains(slot.preferencesKeyPrefix())
+                    }
+
+                // Deleting each key that refers to that slot config.
+                slotRelatedKeys.forEach { mutablePreferences.remove(it) }
+            }
+        }
+
+        fun getDefaultSlotConfiguration(slot: ZeSlot): ZeConfiguration =
+            when (slot) {
+                is ZeSlot.Name ->
+                    ZeConfiguration.Name(
+                        null,
+                        null,
+                        imageProviderService.getInitialNameBitmap(),
+                    )
+
+                is ZeSlot.FirstSponsor -> ZeConfiguration.Picture(R.drawable.page_google.toBitmap())
+                is ZeSlot.FirstCustom -> ZeConfiguration.Picture(R.drawable.soon.toBitmap())
+                is ZeSlot.SecondCustom -> ZeConfiguration.Picture(R.drawable.soon.toBitmap())
+                ZeSlot.QRCode ->
+                    ZeConfiguration.QRCode(
+                        title = "",
+                        text = "",
+                        url = "",
+                        isVcard = false,
+                        phone = "",
+                        email = "",
+                        bitmap = R.drawable.qrpage_preview.toBitmap(),
+                    )
+
+                ZeSlot.Weather ->
+                    ZeConfiguration.Weather(
+                        LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE),
+                        "22C",
+                        R.drawable.soon.toBitmap(),
+                    )
+
+                is ZeSlot.Quote ->
+                    ZeConfiguration.Quote(
+                        "Test",
+                        "Author",
+                        R.drawable.page_quote_sample.toBitmap(),
+                    )
+
+                ZeSlot.BarCode ->
+                    ZeConfiguration.BarCode(
+                        "Your title for barcode",
+                        "",
+                        R.drawable.soon.toBitmap(),
+                    )
+
+                ZeSlot.Add ->
+                    ZeConfiguration.Name(
+                        null,
+                        null,
+                        imageProviderService.provideImageBitmap(R.drawable.add),
+                    )
+
+                ZeSlot.Camera ->
+                    ZeConfiguration.Camera(
+                        imageProviderService.provideImageBitmap(R.drawable.soon),
+                    )
+            }
+
+        fun getInitialSlots(): List<ZeSlot> =
+            listOf(
+                ZeSlot.Name,
+                ZeSlot.FirstSponsor,
+                ZeSlot.Camera,
+                ZeSlot.Add,
+            )
+
+        // region private implementation methods
+        private fun getSlotConfigurationByType(
+            slot: ZeSlot,
+            type: ZeBadgeType?,
+            bitmap: Bitmap,
+            preferences: Preferences,
+        ) = when (type) {
+            ZeBadgeType.NAME -> {
+                ZeConfiguration.Name(
+                    name = preferences.slotFieldValue(slot, "name"),
+                    contact = preferences.slotFieldValue(slot, "contact"),
+                    bitmap = bitmap,
+                )
+            }
+
+            ZeBadgeType.CUSTOM_PICTURE -> ZeConfiguration.Picture(bitmap)
+
+            ZeBadgeType.IMAGE_GEN ->
+                ZeConfiguration.ImageGen(
+                    prompt = preferences.slotFieldValue(slot, "prompt"),
+                    bitmap = bitmap,
+                )
+
+            ZeBadgeType.GEOFENCE_SCHEDULE -> ZeConfiguration.Schedule(bitmap)
+
+            ZeBadgeType.UPCOMING_WEATHER ->
+                ZeConfiguration.Weather(
+                    date = preferences.slotFieldValue(slot, "weather_date"),
+                    temperature = preferences.slotFieldValue(slot, "weather_temperature"),
+                    bitmap,
+                )
+
+            ZeBadgeType.QR_CODE ->
+                ZeConfiguration.QRCode(
+                    title = preferences.slotFieldValue(slot, "qr_title"),
+                    url = preferences.slotFieldValue(slot, "url"),
+                    text = preferences.slotFieldValue(slot, "qr_text"),
+                    isVcard = preferences.slotFieldValue(slot, "qr_is_vcard").toBoolean(),
+                    phone = preferences.slotFieldValue(slot, "qr_phone"),
+                    email = preferences.slotFieldValue(slot, "qr_email"),
+                    bitmap = bitmap,
+                )
+
+            ZeBadgeType.PHRASE ->
+                ZeConfiguration.CustomPhrase(
+                    phrase = preferences.slotFieldValue(slot, "random_phrase"),
+                    bitmap = bitmap,
+                )
+
+            ZeBadgeType.BARCODE_TAG ->
+                ZeConfiguration.BarCode(
+                    title = preferences.slotFieldValue(slot, "barcode_title"),
+                    bitmap = bitmap,
+                    url = preferences.slotFieldValue(slot, "url"),
+                )
+
+            ZeBadgeType.RANDOM_QUOTE ->
+                ZeConfiguration.Quote(
+                    message = preferences.slotFieldValue(slot, "quote_message"),
+                    author = preferences.slotFieldValue(slot, "quote_author"),
+                    bitmap = bitmap,
+                )
+
+            ZeBadgeType.CAMERA -> ZeConfiguration.Camera(bitmap)
+
+            else -> {
+                Timber.e("Slot from Prefs: Cannot find $type slot in preferences.")
+                null
+            }
+        }
+
+        private fun saveSlotConfigurationByConfig(
+            slot: ZeSlot,
+            config: ZeConfiguration,
+            preferences: MutablePreferences,
+        ) {
+            when (config) {
+                is ZeConfiguration.Name -> {
+                    preferences[slot.preferencesKey("name")] = config.name.orEmpty()
+                    preferences[slot.preferencesKey("contact")] = config.contact.orEmpty()
+                }
+
+                is ZeConfiguration.ImageGen -> {
+                    preferences[slot.preferencesKey("prompt")] = config.prompt
+                }
+
+                is ZeConfiguration.Picture -> {
+                    // Nothing more to configure
+                }
+
+                is ZeConfiguration.Schedule -> {
+                    // TODO: Save schedule
+                }
+
+                is ZeConfiguration.Weather -> {
+                    preferences[slot.preferencesKey("weather_date")] = config.date
+                    preferences[slot.preferencesKey("weather_temperature")] = config.temperature
+                }
+
+                is ZeConfiguration.QRCode -> {
+                    preferences[slot.preferencesKey("qr_title")] = config.title
+                    preferences[slot.preferencesKey("url")] = config.url
+                    preferences[slot.preferencesKey("qr_text")] = config.text
+                    preferences[slot.preferencesKey("qr_phone")] = config.phone
+                    preferences[slot.preferencesKey("qr_email")] = config.email
+                    preferences[slot.preferencesKey("qr_is_vcard")] = config.isVcard.toString()
+                }
+
+                is ZeConfiguration.Camera,
+                is ZeConfiguration.Kodee,
+                -> Unit
+
+                is ZeConfiguration.ImageDraw -> {
+                    // Nothing more to configure
+                }
+
+                is ZeConfiguration.Quote -> {
+                    preferences[slot.preferencesKey("quote_author")] = config.author
+                    preferences[slot.preferencesKey("quote_message")] = config.message
+                }
+
+                is ZeConfiguration.BarCode -> {
+                    preferences[slot.preferencesKey("barcode_title")] = config.title
+                    preferences[slot.preferencesKey("url")] = config.url
+                }
+
+                is ZeConfiguration.CustomPhrase -> {
+                    preferences[slot.preferencesKey("random_phrase")] = config.phrase
+                }
+            }
+        }
+
+        private fun Int.toBitmap(): Bitmap = imageProviderService.provideImageBitmap(this)
+        //endregion
     }
-
-    private fun Int.toBitmap(): Bitmap = imageProviderService.provideImageBitmap(this)
-    //endregion
-}
-
 
 // Helper extension methods
 private fun ZeSlot.preferencesKeyPrefix(): String = "slot.$name"
+
 private fun ZeSlot.preferencesKey(field: String): Preferences.Key<String> = stringPreferencesKey("${this.preferencesKeyPrefix()}.$field")
-private fun Preferences.slotFieldValue(slot: ZeSlot, field: String): String =
+
+private fun Preferences.slotFieldValue(
+    slot: ZeSlot,
+    field: String,
+): String =
     slot.preferencesKey(field).let {
         if (this.contains(it)) {
             this[it]!!
@@ -295,5 +307,3 @@ private fun Preferences.slotFieldValue(slot: ZeSlot, field: String): String =
             ""
         }
     }
-
-

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zerepositories/ZeSlotRepository.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zerepositories/ZeSlotRepository.kt
@@ -1,0 +1,194 @@
+package de.berlindroid.zeapp.zerepositories
+
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
+import de.berlindroid.zeapp.zebits.toBitmap
+import de.berlindroid.zeapp.zemodels.ZeBadgeType
+import de.berlindroid.zeapp.zemodels.ZeConfiguration
+import de.berlindroid.zeapp.zemodels.ZeSlot
+import de.berlindroid.zeapp.zeservices.ZePreferencesService
+import de.berlindroid.zeapp.zeservices.ZePreferencesService.Companion.IMAGE_KEY
+import de.berlindroid.zeapp.zeservices.ZePreferencesService.Companion.TYPE_KEY
+import de.berlindroid.zeapp.zeui.pixelBuffer
+import de.berlindroid.zekompanion.BADGE_HEIGHT
+import de.berlindroid.zekompanion.BADGE_WIDTH
+import de.berlindroid.zekompanion.base64
+import de.berlindroid.zekompanion.debase64
+import de.berlindroid.zekompanion.toBinary
+import kotlinx.coroutines.flow.firstOrNull
+import kotlinx.coroutines.flow.mapNotNull
+import timber.log.Timber
+import javax.inject.Inject
+
+/**
+ * Responsible for all the ZeSlot and ZeSlotConfiguration persistence
+ */
+class ZeSlotRepository @Inject constructor(
+    private val zePreferencesService: ZePreferencesService,
+) {
+    suspend fun getSlotConfiguration(slot: ZeSlot): ZeConfiguration? {
+        return zePreferencesService.dataStore.data.mapNotNull { preferences ->
+
+            val type = ZeBadgeType.getOrNull(preferences[slot.preferencesKey(TYPE_KEY)].orEmpty())
+            val bitmap =
+                preferences[slot.preferencesKey(IMAGE_KEY)]
+                    ?.debase64()
+                    ?.toBitmap(BADGE_WIDTH, BADGE_HEIGHT)
+                    ?: return@mapNotNull null
+
+            when (type) {
+                ZeBadgeType.NAME -> {
+                    ZeConfiguration.Name(
+                        name = preferences.slotFieldValue(slot, "name"),
+                        contact = preferences.slotFieldValue(slot, "contact"),
+                        bitmap = bitmap,
+                    )
+                }
+
+                ZeBadgeType.CUSTOM_PICTURE -> ZeConfiguration.Picture(bitmap)
+
+                ZeBadgeType.IMAGE_GEN ->
+                    ZeConfiguration.ImageGen(
+                        prompt = preferences.slotFieldValue(slot, "prompt"),
+                        bitmap = bitmap,
+                    )
+
+                ZeBadgeType.GEOFENCE_SCHEDULE -> ZeConfiguration.Schedule(bitmap)
+
+                ZeBadgeType.UPCOMING_WEATHER ->
+                    ZeConfiguration.Weather(
+                        date = preferences.slotFieldValue(slot, "weather_date"),
+                        temperature = preferences.slotFieldValue(slot, "weather_temperature"),
+                        bitmap,
+                    )
+
+                ZeBadgeType.QR_CODE ->
+                    ZeConfiguration.QRCode(
+                        title = preferences.slotFieldValue(slot, "qr_title"),
+                        url = preferences.slotFieldValue(slot, "url"),
+                        text = preferences.slotFieldValue(slot, "qr_text"),
+                        isVcard = preferences.slotFieldValue(slot, "qr_is_vcard").toBoolean(),
+                        phone = preferences.slotFieldValue(slot, "qr_phone"),
+                        email = preferences.slotFieldValue(slot, "qr_email"),
+                        bitmap = bitmap,
+                    )
+
+                ZeBadgeType.PHRASE ->
+                    ZeConfiguration.CustomPhrase(
+                        phrase = preferences.slotFieldValue(slot, "random_phrase"),
+                        bitmap = bitmap,
+                    )
+
+                ZeBadgeType.BARCODE_TAG ->
+                    ZeConfiguration.BarCode(
+                        title = preferences.slotFieldValue(slot, "barcode_title"),
+                        bitmap = bitmap,
+                        url = preferences.slotFieldValue(slot, "url"),
+                    )
+
+                ZeBadgeType.RANDOM_QUOTE ->
+                    ZeConfiguration.Quote(
+                        message = preferences.slotFieldValue(slot, "quote_message"),
+                        author = preferences.slotFieldValue(slot, "quote_author"),
+                        bitmap = bitmap,
+                    )
+
+                ZeBadgeType.CAMERA -> ZeConfiguration.Camera(bitmap)
+
+                else -> {
+                    Timber.e("Slot from Prefs: Cannot find $type slot in preferences.")
+                    null
+                }
+            }
+        }.firstOrNull()
+    }
+
+    suspend fun saveSlotConfiguration(slot: ZeSlot, config: ZeConfiguration) {
+        zePreferencesService.dataStore.edit { preferences ->
+            preferences[slot.preferencesKey(TYPE_KEY)] = config.type.rawValue
+            preferences[slot.preferencesKey(IMAGE_KEY)] = config.bitmap.pixelBuffer().toBinary().base64()
+
+            when (config) {
+                is ZeConfiguration.Name -> {
+                    preferences[slot.preferencesKey("name")] = config.name.orEmpty()
+                    preferences[slot.preferencesKey("contact")] = config.contact.orEmpty()
+                }
+
+                is ZeConfiguration.ImageGen -> {
+                    preferences[slot.preferencesKey("prompt")] = config.prompt
+                }
+
+                is ZeConfiguration.Picture -> {
+                    // Nothing more to configure
+                }
+
+                is ZeConfiguration.Schedule -> {
+                    // TODO: Save schedule
+                }
+
+                is ZeConfiguration.Weather -> {
+                    preferences[slot.preferencesKey("weather_date")] = config.date
+                    preferences[slot.preferencesKey("weather_temperature")] = config.temperature
+                }
+
+                is ZeConfiguration.QRCode -> {
+                    preferences[slot.preferencesKey("qr_title")] = config.title
+                    preferences[slot.preferencesKey("url")] = config.url
+                    preferences[slot.preferencesKey("qr_text")] = config.text
+                    preferences[slot.preferencesKey("qr_phone")] = config.phone
+                    preferences[slot.preferencesKey("qr_email")] = config.email
+                    preferences[slot.preferencesKey("qr_is_vcard")] = config.isVcard.toString()
+                }
+
+                is ZeConfiguration.Camera,
+                is ZeConfiguration.Kodee,
+                -> Unit
+
+                is ZeConfiguration.ImageDraw -> {
+                    // Nothing more to configure
+                }
+
+                is ZeConfiguration.Quote -> {
+                    preferences[slot.preferencesKey("quote_author")] = config.author
+                    preferences[slot.preferencesKey("quote_message")] = config.message
+                }
+
+                is ZeConfiguration.BarCode -> {
+                    preferences[slot.preferencesKey("barcode_title")] = config.title
+                    preferences[slot.preferencesKey("url")] = config.url
+                }
+
+                is ZeConfiguration.CustomPhrase -> {
+                    preferences[slot.preferencesKey("random_phrase")] = config.phrase
+                }
+            }
+        }
+    }
+
+    suspend fun removeSlotConfiguration(slot: ZeSlot) {
+        TODO("Not yet implemented")
+    }
+
+    fun getDefaultSlotConfiguration(slot: ZeSlot): ZeConfiguration {
+        TODO("Not yet implemented")
+    }
+
+    fun getInitialSlots(): List<ZeSlot> {
+        TODO("Not yet implemented")
+    }
+}
+
+
+// Helper extension methods
+private fun ZeSlot.preferencesKey(field: String): Preferences.Key<String> = stringPreferencesKey("slot.$name.$field")
+private fun Preferences.slotFieldValue(slot: ZeSlot, field: String): String =
+    slot.preferencesKey(field).let {
+        if (this.contains(it)) {
+            this[it]!!
+        } else {
+            ""
+        }
+    }
+
+

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zerepositories/ZeSlotRepository.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zerepositories/ZeSlotRepository.kt
@@ -1,15 +1,17 @@
 package de.berlindroid.zeapp.zerepositories
 
+import android.graphics.Bitmap
+import androidx.datastore.preferences.core.MutablePreferences
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
+import de.berlindroid.zeapp.R
 import de.berlindroid.zeapp.zebits.toBitmap
 import de.berlindroid.zeapp.zemodels.ZeBadgeType
 import de.berlindroid.zeapp.zemodels.ZeConfiguration
 import de.berlindroid.zeapp.zemodels.ZeSlot
+import de.berlindroid.zeapp.zeservices.ZeImageProviderService
 import de.berlindroid.zeapp.zeservices.ZePreferencesService
-import de.berlindroid.zeapp.zeservices.ZePreferencesService.Companion.IMAGE_KEY
-import de.berlindroid.zeapp.zeservices.ZePreferencesService.Companion.TYPE_KEY
 import de.berlindroid.zeapp.zeui.pixelBuffer
 import de.berlindroid.zekompanion.BADGE_HEIGHT
 import de.berlindroid.zekompanion.BADGE_WIDTH
@@ -17,90 +19,43 @@ import de.berlindroid.zekompanion.base64
 import de.berlindroid.zekompanion.debase64
 import de.berlindroid.zekompanion.toBinary
 import kotlinx.coroutines.flow.firstOrNull
-import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.map
 import timber.log.Timber
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 /**
  * Responsible for all the ZeSlot and ZeSlotConfiguration persistence
+ * It provides easy access methods to
+ * [getSlotConfiguration], [saveSlotConfiguration], [removeSlotConfiguration], [getDefaultSlotConfiguration] and [getInitialSlots]
  */
 class ZeSlotRepository @Inject constructor(
     private val zePreferencesService: ZePreferencesService,
+    private val imageProviderService: ZeImageProviderService,
 ) {
+    // Constants
+    private companion object {
+        const val TYPE_KEY = "type"
+        const val IMAGE_KEY = "bitmap"
+    }
+
     suspend fun getSlotConfiguration(slot: ZeSlot): ZeConfiguration? {
-        return zePreferencesService.dataStore.data.mapNotNull { preferences ->
+        return zePreferencesService.dataStore.data.map { preferences ->
 
             val type = ZeBadgeType.getOrNull(preferences[slot.preferencesKey(TYPE_KEY)].orEmpty())
             val bitmap =
                 preferences[slot.preferencesKey(IMAGE_KEY)]
                     ?.debase64()
                     ?.toBitmap(BADGE_WIDTH, BADGE_HEIGHT)
-                    ?: return@mapNotNull null
+                    ?: return@map null
 
-            when (type) {
-                ZeBadgeType.NAME -> {
-                    ZeConfiguration.Name(
-                        name = preferences.slotFieldValue(slot, "name"),
-                        contact = preferences.slotFieldValue(slot, "contact"),
-                        bitmap = bitmap,
-                    )
-                }
-
-                ZeBadgeType.CUSTOM_PICTURE -> ZeConfiguration.Picture(bitmap)
-
-                ZeBadgeType.IMAGE_GEN ->
-                    ZeConfiguration.ImageGen(
-                        prompt = preferences.slotFieldValue(slot, "prompt"),
-                        bitmap = bitmap,
-                    )
-
-                ZeBadgeType.GEOFENCE_SCHEDULE -> ZeConfiguration.Schedule(bitmap)
-
-                ZeBadgeType.UPCOMING_WEATHER ->
-                    ZeConfiguration.Weather(
-                        date = preferences.slotFieldValue(slot, "weather_date"),
-                        temperature = preferences.slotFieldValue(slot, "weather_temperature"),
-                        bitmap,
-                    )
-
-                ZeBadgeType.QR_CODE ->
-                    ZeConfiguration.QRCode(
-                        title = preferences.slotFieldValue(slot, "qr_title"),
-                        url = preferences.slotFieldValue(slot, "url"),
-                        text = preferences.slotFieldValue(slot, "qr_text"),
-                        isVcard = preferences.slotFieldValue(slot, "qr_is_vcard").toBoolean(),
-                        phone = preferences.slotFieldValue(slot, "qr_phone"),
-                        email = preferences.slotFieldValue(slot, "qr_email"),
-                        bitmap = bitmap,
-                    )
-
-                ZeBadgeType.PHRASE ->
-                    ZeConfiguration.CustomPhrase(
-                        phrase = preferences.slotFieldValue(slot, "random_phrase"),
-                        bitmap = bitmap,
-                    )
-
-                ZeBadgeType.BARCODE_TAG ->
-                    ZeConfiguration.BarCode(
-                        title = preferences.slotFieldValue(slot, "barcode_title"),
-                        bitmap = bitmap,
-                        url = preferences.slotFieldValue(slot, "url"),
-                    )
-
-                ZeBadgeType.RANDOM_QUOTE ->
-                    ZeConfiguration.Quote(
-                        message = preferences.slotFieldValue(slot, "quote_message"),
-                        author = preferences.slotFieldValue(slot, "quote_author"),
-                        bitmap = bitmap,
-                    )
-
-                ZeBadgeType.CAMERA -> ZeConfiguration.Camera(bitmap)
-
-                else -> {
-                    Timber.e("Slot from Prefs: Cannot find $type slot in preferences.")
-                    null
-                }
-            }
+            return@map getSlotConfigurationByType(
+                slot = slot,
+                type = type,
+                bitmap = bitmap,
+                preferences = preferences,
+            )
         }.firstOrNull()
     }
 
@@ -109,79 +64,229 @@ class ZeSlotRepository @Inject constructor(
             preferences[slot.preferencesKey(TYPE_KEY)] = config.type.rawValue
             preferences[slot.preferencesKey(IMAGE_KEY)] = config.bitmap.pixelBuffer().toBinary().base64()
 
-            when (config) {
-                is ZeConfiguration.Name -> {
-                    preferences[slot.preferencesKey("name")] = config.name.orEmpty()
-                    preferences[slot.preferencesKey("contact")] = config.contact.orEmpty()
-                }
-
-                is ZeConfiguration.ImageGen -> {
-                    preferences[slot.preferencesKey("prompt")] = config.prompt
-                }
-
-                is ZeConfiguration.Picture -> {
-                    // Nothing more to configure
-                }
-
-                is ZeConfiguration.Schedule -> {
-                    // TODO: Save schedule
-                }
-
-                is ZeConfiguration.Weather -> {
-                    preferences[slot.preferencesKey("weather_date")] = config.date
-                    preferences[slot.preferencesKey("weather_temperature")] = config.temperature
-                }
-
-                is ZeConfiguration.QRCode -> {
-                    preferences[slot.preferencesKey("qr_title")] = config.title
-                    preferences[slot.preferencesKey("url")] = config.url
-                    preferences[slot.preferencesKey("qr_text")] = config.text
-                    preferences[slot.preferencesKey("qr_phone")] = config.phone
-                    preferences[slot.preferencesKey("qr_email")] = config.email
-                    preferences[slot.preferencesKey("qr_is_vcard")] = config.isVcard.toString()
-                }
-
-                is ZeConfiguration.Camera,
-                is ZeConfiguration.Kodee,
-                -> Unit
-
-                is ZeConfiguration.ImageDraw -> {
-                    // Nothing more to configure
-                }
-
-                is ZeConfiguration.Quote -> {
-                    preferences[slot.preferencesKey("quote_author")] = config.author
-                    preferences[slot.preferencesKey("quote_message")] = config.message
-                }
-
-                is ZeConfiguration.BarCode -> {
-                    preferences[slot.preferencesKey("barcode_title")] = config.title
-                    preferences[slot.preferencesKey("url")] = config.url
-                }
-
-                is ZeConfiguration.CustomPhrase -> {
-                    preferences[slot.preferencesKey("random_phrase")] = config.phrase
-                }
-            }
+            saveSlotConfigurationByConfig(
+                slot = slot,
+                config = config,
+                preferences = preferences,
+            )
         }
     }
 
     suspend fun removeSlotConfiguration(slot: ZeSlot) {
-        TODO("Not yet implemented")
+        zePreferencesService.dataStore.edit { mutablePreferences ->
+            // Getting all related information about the slot config.
+            val slotRelatedKeys = mutablePreferences.asMap().keys.filter {
+                it.name.contains(slot.preferencesKeyPrefix())
+            }
+
+            // Deleting each key that refers to that slot config.
+            slotRelatedKeys.forEach { mutablePreferences.remove(it) }
+        }
     }
 
-    fun getDefaultSlotConfiguration(slot: ZeSlot): ZeConfiguration {
-        TODO("Not yet implemented")
+    fun getDefaultSlotConfiguration(slot: ZeSlot): ZeConfiguration = when (slot) {
+        is ZeSlot.Name ->
+            ZeConfiguration.Name(
+                null,
+                null,
+                imageProviderService.getInitialNameBitmap(),
+            )
+
+        is ZeSlot.FirstSponsor -> ZeConfiguration.Picture(R.drawable.page_google.toBitmap())
+        is ZeSlot.FirstCustom -> ZeConfiguration.Picture(R.drawable.soon.toBitmap())
+        is ZeSlot.SecondCustom -> ZeConfiguration.Picture(R.drawable.soon.toBitmap())
+        ZeSlot.QRCode ->
+            ZeConfiguration.QRCode(
+                title = "",
+                text = "",
+                url = "",
+                isVcard = false,
+                phone = "",
+                email = "",
+                bitmap = R.drawable.qrpage_preview.toBitmap(),
+            )
+
+        ZeSlot.Weather ->
+            ZeConfiguration.Weather(
+                LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE),
+                "22C",
+                R.drawable.soon.toBitmap(),
+            )
+
+        is ZeSlot.Quote ->
+            ZeConfiguration.Quote(
+                "Test",
+                "Author",
+                R.drawable.page_quote_sample.toBitmap(),
+            )
+
+        ZeSlot.BarCode ->
+            ZeConfiguration.BarCode(
+                "Your title for barcode",
+                "",
+                R.drawable.soon.toBitmap(),
+            )
+
+        ZeSlot.Add ->
+            ZeConfiguration.Name(
+                null,
+                null,
+                imageProviderService.provideImageBitmap(R.drawable.add),
+            )
+
+        ZeSlot.Camera ->
+            ZeConfiguration.Camera(
+                imageProviderService.provideImageBitmap(R.drawable.soon),
+            )
     }
 
-    fun getInitialSlots(): List<ZeSlot> {
-        TODO("Not yet implemented")
+    fun getInitialSlots(): List<ZeSlot> = listOf(
+        ZeSlot.Name,
+        ZeSlot.FirstSponsor,
+        ZeSlot.Camera,
+        ZeSlot.Add,
+    )
+
+    // region private implementation methods
+    private fun getSlotConfigurationByType(
+        slot: ZeSlot,
+        type: ZeBadgeType?,
+        bitmap: Bitmap,
+        preferences: Preferences,
+    ) = when (type) {
+        ZeBadgeType.NAME -> {
+            ZeConfiguration.Name(
+                name = preferences.slotFieldValue(slot, "name"),
+                contact = preferences.slotFieldValue(slot, "contact"),
+                bitmap = bitmap,
+            )
+        }
+
+        ZeBadgeType.CUSTOM_PICTURE -> ZeConfiguration.Picture(bitmap)
+
+        ZeBadgeType.IMAGE_GEN ->
+            ZeConfiguration.ImageGen(
+                prompt = preferences.slotFieldValue(slot, "prompt"),
+                bitmap = bitmap,
+            )
+
+        ZeBadgeType.GEOFENCE_SCHEDULE -> ZeConfiguration.Schedule(bitmap)
+
+        ZeBadgeType.UPCOMING_WEATHER ->
+            ZeConfiguration.Weather(
+                date = preferences.slotFieldValue(slot, "weather_date"),
+                temperature = preferences.slotFieldValue(slot, "weather_temperature"),
+                bitmap,
+            )
+
+        ZeBadgeType.QR_CODE ->
+            ZeConfiguration.QRCode(
+                title = preferences.slotFieldValue(slot, "qr_title"),
+                url = preferences.slotFieldValue(slot, "url"),
+                text = preferences.slotFieldValue(slot, "qr_text"),
+                isVcard = preferences.slotFieldValue(slot, "qr_is_vcard").toBoolean(),
+                phone = preferences.slotFieldValue(slot, "qr_phone"),
+                email = preferences.slotFieldValue(slot, "qr_email"),
+                bitmap = bitmap,
+            )
+
+        ZeBadgeType.PHRASE ->
+            ZeConfiguration.CustomPhrase(
+                phrase = preferences.slotFieldValue(slot, "random_phrase"),
+                bitmap = bitmap,
+            )
+
+        ZeBadgeType.BARCODE_TAG ->
+            ZeConfiguration.BarCode(
+                title = preferences.slotFieldValue(slot, "barcode_title"),
+                bitmap = bitmap,
+                url = preferences.slotFieldValue(slot, "url"),
+            )
+
+        ZeBadgeType.RANDOM_QUOTE ->
+            ZeConfiguration.Quote(
+                message = preferences.slotFieldValue(slot, "quote_message"),
+                author = preferences.slotFieldValue(slot, "quote_author"),
+                bitmap = bitmap,
+            )
+
+        ZeBadgeType.CAMERA -> ZeConfiguration.Camera(bitmap)
+
+        else -> {
+            Timber.e("Slot from Prefs: Cannot find $type slot in preferences.")
+            null
+        }
     }
+
+    private fun saveSlotConfigurationByConfig(
+        slot: ZeSlot,
+        config: ZeConfiguration,
+        preferences: MutablePreferences,
+    ) {
+        when (config) {
+            is ZeConfiguration.Name -> {
+                preferences[slot.preferencesKey("name")] = config.name.orEmpty()
+                preferences[slot.preferencesKey("contact")] = config.contact.orEmpty()
+            }
+
+            is ZeConfiguration.ImageGen -> {
+                preferences[slot.preferencesKey("prompt")] = config.prompt
+            }
+
+            is ZeConfiguration.Picture -> {
+                // Nothing more to configure
+            }
+
+            is ZeConfiguration.Schedule -> {
+                // TODO: Save schedule
+            }
+
+            is ZeConfiguration.Weather -> {
+                preferences[slot.preferencesKey("weather_date")] = config.date
+                preferences[slot.preferencesKey("weather_temperature")] = config.temperature
+            }
+
+            is ZeConfiguration.QRCode -> {
+                preferences[slot.preferencesKey("qr_title")] = config.title
+                preferences[slot.preferencesKey("url")] = config.url
+                preferences[slot.preferencesKey("qr_text")] = config.text
+                preferences[slot.preferencesKey("qr_phone")] = config.phone
+                preferences[slot.preferencesKey("qr_email")] = config.email
+                preferences[slot.preferencesKey("qr_is_vcard")] = config.isVcard.toString()
+            }
+
+            is ZeConfiguration.Camera,
+            is ZeConfiguration.Kodee,
+            -> Unit
+
+            is ZeConfiguration.ImageDraw -> {
+                // Nothing more to configure
+            }
+
+            is ZeConfiguration.Quote -> {
+                preferences[slot.preferencesKey("quote_author")] = config.author
+                preferences[slot.preferencesKey("quote_message")] = config.message
+            }
+
+            is ZeConfiguration.BarCode -> {
+                preferences[slot.preferencesKey("barcode_title")] = config.title
+                preferences[slot.preferencesKey("url")] = config.url
+            }
+
+            is ZeConfiguration.CustomPhrase -> {
+                preferences[slot.preferencesKey("random_phrase")] = config.phrase
+            }
+        }
+    }
+
+    private fun Int.toBitmap(): Bitmap = imageProviderService.provideImageBitmap(this)
+    //endregion
 }
 
 
 // Helper extension methods
-private fun ZeSlot.preferencesKey(field: String): Preferences.Key<String> = stringPreferencesKey("slot.$name.$field")
+private fun ZeSlot.preferencesKeyPrefix(): String = "slot.$name"
+private fun ZeSlot.preferencesKey(field: String): Preferences.Key<String> = stringPreferencesKey("${this.preferencesKeyPrefix()}.$field")
 private fun Preferences.slotFieldValue(slot: ZeSlot, field: String): String =
     slot.preferencesKey(field).let {
         if (this.contains(it)) {

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeservices/ZePreferencesService.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeservices/ZePreferencesService.kt
@@ -9,21 +9,9 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
-import de.berlindroid.zeapp.zebits.toBitmap
-import de.berlindroid.zeapp.zemodels.ZeBadgeType
-import de.berlindroid.zeapp.zemodels.ZeConfiguration
 import de.berlindroid.zeapp.zemodels.ZeSlot
-import de.berlindroid.zeapp.zeui.pixelBuffer
-import de.berlindroid.zekompanion.BADGE_HEIGHT
-import de.berlindroid.zekompanion.BADGE_WIDTH
-import de.berlindroid.zekompanion.base64
-import de.berlindroid.zekompanion.debase64
-import de.berlindroid.zekompanion.toBinary
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.map
-import kotlinx.coroutines.flow.mapNotNull
-import timber.log.Timber
 import javax.inject.Inject
 
 private const val PREFS_NAME = "defaults"
@@ -35,193 +23,39 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
 )
 
 class ZePreferencesService
-    @Inject
-    constructor(
-        @ApplicationContext private val context: Context,
-    ) {
-        private companion object {
-            val OPEN_API_PREFERENCES_KEY = stringPreferencesKey("openapi")
-            const val TYPE_KEY = "type"
-            const val IMAGE_KEY = "bitmap"
-            val THEME_KEY = intPreferencesKey("theme")
-        }
-
-        private val dataStore = context.dataStore
-
-        suspend fun getOpenApiKey(): String {
-            return dataStore.data.map { preferences -> preferences[OPEN_API_PREFERENCES_KEY].orEmpty() }
-                .first()
-        }
-
-        suspend fun isSlotConfigured(slot: ZeSlot): Boolean {
-            return dataStore.data.map { preferences -> preferences.contains(slot.preferencesKey(TYPE_KEY)) }
-                .first()
-        }
-
-        suspend fun saveSlotConfiguration(
-            slot: ZeSlot,
-            config: ZeConfiguration,
-        ) {
-            dataStore.edit { preferences ->
-                preferences[slot.preferencesKey(TYPE_KEY)] = config.type.rawValue
-                preferences[slot.preferencesKey(IMAGE_KEY)] = config.bitmap.pixelBuffer().toBinary().base64()
-
-                when (config) {
-                    is ZeConfiguration.Name -> {
-                        preferences[slot.preferencesKey("name")] = config.name.orEmpty()
-                        preferences[slot.preferencesKey("contact")] = config.contact.orEmpty()
-                    }
-
-                    is ZeConfiguration.ImageGen -> {
-                        preferences[slot.preferencesKey("prompt")] = config.prompt
-                    }
-
-                    is ZeConfiguration.Picture -> {
-                        // Nothing more to configure
-                    }
-
-                    is ZeConfiguration.Schedule -> {
-                        // TODO: Save schedule
-                    }
-
-                    is ZeConfiguration.Weather -> {
-                        preferences[slot.preferencesKey("weather_date")] = config.date
-                        preferences[slot.preferencesKey("weather_temperature")] = config.temperature
-                    }
-
-                    is ZeConfiguration.QRCode -> {
-                        preferences[slot.preferencesKey("qr_title")] = config.title
-                        preferences[slot.preferencesKey("url")] = config.url
-                        preferences[slot.preferencesKey("qr_text")] = config.text
-                        preferences[slot.preferencesKey("qr_phone")] = config.phone
-                        preferences[slot.preferencesKey("qr_email")] = config.email
-                        preferences[slot.preferencesKey("qr_is_vcard")] = config.isVcard.toString()
-                    }
-
-                    is ZeConfiguration.Camera,
-                    is ZeConfiguration.Kodee,
-                    -> Unit
-
-                    is ZeConfiguration.ImageDraw -> {
-                        // Nothing more to configure
-                    }
-
-                    is ZeConfiguration.Quote -> {
-                        preferences[slot.preferencesKey("quote_author")] = config.author
-                        preferences[slot.preferencesKey("quote_message")] = config.message
-                    }
-
-                    is ZeConfiguration.BarCode -> {
-                        preferences[slot.preferencesKey("barcode_title")] = config.title
-                        preferences[slot.preferencesKey("url")] = config.url
-                    }
-
-                    is ZeConfiguration.CustomPhrase -> {
-                        preferences[slot.preferencesKey("random_phrase")] = config.phrase
-                    }
-                }
-            }
-        }
-
-        suspend fun getThemeSettings(): Int {
-            return dataStore.data.map { preferences -> preferences[THEME_KEY] ?: 0 }
-                .first()
-        }
-
-        suspend fun setThemeSettings(themeSettings: Int) {
-            dataStore.edit { preferences ->
-                preferences[THEME_KEY] = themeSettings
-            }
-        }
-
-        suspend fun getSlotConfiguration(slot: ZeSlot): ZeConfiguration? {
-            return dataStore.data.mapNotNull { preferences ->
-
-                val type = ZeBadgeType.getOrNull(preferences[slot.preferencesKey(TYPE_KEY)].orEmpty())
-                val bitmap =
-                    preferences[slot.preferencesKey(IMAGE_KEY)]
-                        ?.debase64()
-                        ?.toBitmap(BADGE_WIDTH, BADGE_HEIGHT)
-                        ?: return@mapNotNull null
-
-                when (type) {
-                    ZeBadgeType.NAME -> {
-                        ZeConfiguration.Name(
-                            name = slot.preferencesValue("name"),
-                            contact = slot.preferencesValue("contact"),
-                            bitmap = bitmap,
-                        )
-                    }
-
-                    ZeBadgeType.CUSTOM_PICTURE -> ZeConfiguration.Picture(bitmap)
-
-                    ZeBadgeType.IMAGE_GEN ->
-                        ZeConfiguration.ImageGen(
-                            prompt = slot.preferencesValue("prompt"),
-                            bitmap = bitmap,
-                        )
-
-                    ZeBadgeType.GEOFENCE_SCHEDULE -> ZeConfiguration.Schedule(bitmap)
-
-                    ZeBadgeType.UPCOMING_WEATHER ->
-                        ZeConfiguration.Weather(
-                            date = slot.preferencesValue("weather_date"),
-                            temperature = slot.preferencesValue("weather_temperature"),
-                            bitmap,
-                        )
-
-                    ZeBadgeType.QR_CODE ->
-                        ZeConfiguration.QRCode(
-                            title = slot.preferencesValue("qr_title"),
-                            url = slot.preferencesValue("url"),
-                            text = slot.preferencesValue("qr_text"),
-                            isVcard = slot.preferencesBooleanValue("qr_is_vcard"),
-                            phone = slot.preferencesValue("qr_phone"),
-                            email = slot.preferencesValue("qr_email"),
-                            bitmap = bitmap,
-                        )
-
-                    ZeBadgeType.PHRASE ->
-                        ZeConfiguration.CustomPhrase(
-                            phrase = slot.preferencesValue("random_phrase"),
-                            bitmap = bitmap,
-                        )
-
-                    ZeBadgeType.BARCODE_TAG ->
-                        ZeConfiguration.BarCode(
-                            title = slot.preferencesValue("barcode_title"),
-                            bitmap = bitmap,
-                            url = slot.preferencesValue("url"),
-                        )
-
-                    ZeBadgeType.RANDOM_QUOTE ->
-                        ZeConfiguration.Quote(
-                            message = slot.preferencesValue("quote_message"),
-                            author = slot.preferencesValue("quote_author"),
-                            bitmap = bitmap,
-                        )
-
-                    ZeBadgeType.CAMERA -> ZeConfiguration.Camera(bitmap)
-
-                    else -> {
-                        Timber.e("Slot from Prefs: Cannot find $type slot in preferences.")
-                        null
-                    }
-                }
-            }.firstOrNull()
-        }
-
-        private fun ZeSlot.preferencesKey(field: String): Preferences.Key<String> = stringPreferencesKey("slot.$name.$field")
-
-        private suspend fun ZeSlot.preferencesValue(field: String): String =
-            dataStore.data.map { preferences ->
-                val key = preferencesKey(field)
-                if (preferences.contains(key)) {
-                    preferences[key]!!
-                } else {
-                    ""
-                }
-            }.first()
-
-        private suspend fun ZeSlot.preferencesBooleanValue(field: String): Boolean = preferencesValue(field).toBoolean()
+@Inject
+constructor(
+    @ApplicationContext private val context: Context,
+) {
+    companion object {
+        const val TYPE_KEY = "type"
+        const val IMAGE_KEY = "bitmap"
+        private val OPEN_API_PREFERENCES_KEY = stringPreferencesKey("openapi")
+        private val THEME_KEY = intPreferencesKey("theme")
     }
+
+    val dataStore = context.dataStore
+
+    suspend fun getOpenApiKey(): String {
+        return dataStore.data.map { preferences -> preferences[OPEN_API_PREFERENCES_KEY].orEmpty() }
+            .first()
+    }
+
+    suspend fun isSlotConfigured(slot: ZeSlot): Boolean {
+        return dataStore.data.map { preferences -> preferences.contains(slot.preferencesKey(TYPE_KEY)) }
+            .first()
+    }
+
+    suspend fun getThemeSettings(): Int {
+        return dataStore.data.map { preferences -> preferences[THEME_KEY] ?: 0 }
+            .first()
+    }
+
+    suspend fun setThemeSettings(themeSettings: Int) {
+        dataStore.edit { preferences ->
+            preferences[THEME_KEY] = themeSettings
+        }
+    }
+
+    private fun ZeSlot.preferencesKey(field: String): Preferences.Key<String> = stringPreferencesKey("slot.$name.$field")
+}

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeservices/ZePreferencesService.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeservices/ZePreferencesService.kt
@@ -28,8 +28,6 @@ constructor(
     @ApplicationContext private val context: Context,
 ) {
     companion object {
-        const val TYPE_KEY = "type"
-        const val IMAGE_KEY = "bitmap"
         private val OPEN_API_PREFERENCES_KEY = stringPreferencesKey("openapi")
         private val THEME_KEY = intPreferencesKey("theme")
     }
@@ -38,11 +36,6 @@ constructor(
 
     suspend fun getOpenApiKey(): String {
         return dataStore.data.map { preferences -> preferences[OPEN_API_PREFERENCES_KEY].orEmpty() }
-            .first()
-    }
-
-    suspend fun isSlotConfigured(slot: ZeSlot): Boolean {
-        return dataStore.data.map { preferences -> preferences.contains(slot.preferencesKey(TYPE_KEY)) }
             .first()
     }
 
@@ -56,6 +49,4 @@ constructor(
             preferences[THEME_KEY] = themeSettings
         }
     }
-
-    private fun ZeSlot.preferencesKey(field: String): Preferences.Key<String> = stringPreferencesKey("slot.$name.$field")
 }

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zeservices/ZePreferencesService.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zeservices/ZePreferencesService.kt
@@ -9,7 +9,6 @@ import androidx.datastore.preferences.core.intPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import dagger.hilt.android.qualifiers.ApplicationContext
-import de.berlindroid.zeapp.zemodels.ZeSlot
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import javax.inject.Inject
@@ -23,30 +22,30 @@ private val Context.dataStore: DataStore<Preferences> by preferencesDataStore(
 )
 
 class ZePreferencesService
-@Inject
-constructor(
-    @ApplicationContext private val context: Context,
-) {
-    companion object {
-        private val OPEN_API_PREFERENCES_KEY = stringPreferencesKey("openapi")
-        private val THEME_KEY = intPreferencesKey("theme")
-    }
+    @Inject
+    constructor(
+        @ApplicationContext private val context: Context,
+    ) {
+        companion object {
+            private val OPEN_API_PREFERENCES_KEY = stringPreferencesKey("openapi")
+            private val THEME_KEY = intPreferencesKey("theme")
+        }
 
-    val dataStore = context.dataStore
+        val dataStore = context.dataStore
 
-    suspend fun getOpenApiKey(): String {
-        return dataStore.data.map { preferences -> preferences[OPEN_API_PREFERENCES_KEY].orEmpty() }
-            .first()
-    }
+        suspend fun getOpenApiKey(): String {
+            return dataStore.data.map { preferences -> preferences[OPEN_API_PREFERENCES_KEY].orEmpty() }
+                .first()
+        }
 
-    suspend fun getThemeSettings(): Int {
-        return dataStore.data.map { preferences -> preferences[THEME_KEY] ?: 0 }
-            .first()
-    }
+        suspend fun getThemeSettings(): Int {
+            return dataStore.data.map { preferences -> preferences[THEME_KEY] ?: 0 }
+                .first()
+        }
 
-    suspend fun setThemeSettings(themeSettings: Int) {
-        dataStore.edit { preferences ->
-            preferences[THEME_KEY] = themeSettings
+        suspend fun setThemeSettings(themeSettings: Int) {
+            dataStore.edit { preferences ->
+                preferences[THEME_KEY] = themeSettings
+            }
         }
     }
-}

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zevm/ZeBadgeViewModel.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zevm/ZeBadgeViewModel.kt
@@ -45,139 +45,139 @@ private const val MESSAGE_DISPLAY_UPDATES = 5
  */
 @HiltViewModel
 class ZeBadgeViewModel
-@Inject
-constructor(
-    private val imageProviderService: ZeImageProviderService,
-    private val badgeManager: ZeBadgeManager,
-    private val preferencesService: ZePreferencesService,
-    private val zeSlotRepository: ZeSlotRepository,
-    private val clipboardService: ZeClipboardService,
-    private val weatherService: ZeWeatherService,
-    private val getTemplateConfigurations: GetTemplateConfigurations,
-) : ViewModel() {
-    private val _uiState: MutableStateFlow<ZeBadgeUiState> = MutableStateFlow(getInitialUIState())
-    val uiState: StateFlow<ZeBadgeUiState> = _uiState.asStateFlow()
+    @Inject
+    constructor(
+        private val imageProviderService: ZeImageProviderService,
+        private val badgeManager: ZeBadgeManager,
+        private val preferencesService: ZePreferencesService,
+        private val zeSlotRepository: ZeSlotRepository,
+        private val clipboardService: ZeClipboardService,
+        private val weatherService: ZeWeatherService,
+        private val getTemplateConfigurations: GetTemplateConfigurations,
+    ) : ViewModel() {
+        private val _uiState: MutableStateFlow<ZeBadgeUiState> = MutableStateFlow(getInitialUIState())
+        val uiState: StateFlow<ZeBadgeUiState> = _uiState.asStateFlow()
 
-    private val _errorUiState: MutableStateFlow<ZeBadgeErrorUiState> = MutableStateFlow(ZeBadgeErrorUiState.Initial)
-    val errorUiState: StateFlow<ZeBadgeErrorUiState> = _errorUiState.asStateFlow()
+        private val _errorUiState: MutableStateFlow<ZeBadgeErrorUiState> = MutableStateFlow(ZeBadgeErrorUiState.Initial)
+        val errorUiState: StateFlow<ZeBadgeErrorUiState> = _errorUiState.asStateFlow()
 
-    // See if disappearing message is ongoing
-    private var hideMessageJob: Job? = null
-    private var messageProgressJob: Job? = null
+        // See if disappearing message is ongoing
+        private var hideMessageJob: Job? = null
+        private var messageProgressJob: Job? = null
 
-    // This needed to be created to avoid refactoring all the comoposables
-    // We should avoid passing down the VM and pass only the state
+        // This needed to be created to avoid refactoring all the comoposables
+        // We should avoid passing down the VM and pass only the state
 
-    // Represents the current slot showing on the simulator
-    var currentSimulatorSlot by mutableStateOf(zeSlotRepository.getInitialSlots().first())
-        private set
+        // Represents the current slot showing on the simulator
+        var currentSimulatorSlot by mutableStateOf(zeSlotRepository.getInitialSlots().first())
+            private set
 
-    init {
-        loadData()
-    }
-
-    fun showMessage(
-        message: String,
-        showAsError: Boolean = false,
-        duration: Long = MESSAGE_DISPLAY_DURATION,
-    ) {
-        _uiState.update {
-            it.copy(message = it.message + message)
+        init {
+            loadData()
         }
 
-        scheduleMessageDisappearance(duration)
-
-        if (showAsError) {
-            emitSnackBarAction(message = message)
-        }
-    }
-
-    private fun emitSnackBarAction(message: String) {
-        _errorUiState.value = ZeBadgeErrorUiState.ShowError(message)
-    }
-
-    private fun scheduleMessageDisappearance(duration: Long = MESSAGE_DISPLAY_DURATION) {
-        hideMessageJob?.cancel()
-        hideMessageJob =
-            viewModelScope.launch {
-                delay(duration)
-                _uiState.update {
-                    it.copy(message = "")
-                }
+        fun showMessage(
+            message: String,
+            showAsError: Boolean = false,
+            duration: Long = MESSAGE_DISPLAY_DURATION,
+        ) {
+            _uiState.update {
+                it.copy(message = it.message + message)
             }
 
-        messageProgressJob?.cancel()
-        messageProgressJob =
-            viewModelScope.launch {
-                for (progress in 0 until MESSAGE_DISPLAY_UPDATES) {
+            scheduleMessageDisappearance(duration)
+
+            if (showAsError) {
+                emitSnackBarAction(message = message)
+            }
+        }
+
+        private fun emitSnackBarAction(message: String) {
+            _errorUiState.value = ZeBadgeErrorUiState.ShowError(message)
+        }
+
+        private fun scheduleMessageDisappearance(duration: Long = MESSAGE_DISPLAY_DURATION) {
+            hideMessageJob?.cancel()
+            hideMessageJob =
+                viewModelScope.launch {
+                    delay(duration)
                     _uiState.update {
-                        it.copy(messageProgress = 1.0f - progress / MESSAGE_DISPLAY_UPDATES.toFloat())
+                        it.copy(message = "")
                     }
-                    delay(duration / MESSAGE_DISPLAY_UPDATES)
                 }
+
+            messageProgressJob?.cancel()
+            messageProgressJob =
+                viewModelScope.launch {
+                    for (progress in 0 until MESSAGE_DISPLAY_UPDATES) {
+                        _uiState.update {
+                            it.copy(messageProgress = 1.0f - progress / MESSAGE_DISPLAY_UPDATES.toFloat())
+                        }
+                        delay(duration / MESSAGE_DISPLAY_UPDATES)
+                    }
+                }
+        }
+
+        /**
+         * Call this method to send a given slot to the badge device.
+         *
+         * @param slot to be sent.
+         */
+        fun sendPageToBadgeAndDisplay(slot: ZeSlot) {
+            _uiState.update {
+                it.copy(message = "")
             }
-    }
 
-    /**
-     * Call this method to send a given slot to the badge device.
-     *
-     * @param slot to be sent.
-     */
-    fun sendPageToBadgeAndDisplay(slot: ZeSlot) {
-        _uiState.update {
-            it.copy(message = "")
+            val slots = _uiState.value.slots
+
+            val configuration =
+                slots.getOrElse(slot) {
+                    Timber.e("VM: Slot $slot is not one of our slots.")
+                    null
+                } ?: return
+
+            val bitmap = configuration.bitmap
+            if (!bitmap.isBinary()) {
+                showMessage("Please create a binary image for page '${slot.name}'.")
+                return
+            }
+
+            if (!badgeManager.isConnected()) {
+                showMessage("Please connect a badge.")
+                return
+            }
+
+            viewModelScope.launch {
+                badgeManager.storePage(configuration.type.name, bitmap).fold(
+                    onSuccess = { storeResult ->
+                        delay(300) // serial stuff
+                        badgeManager.showPage(configuration.type.name).fold(
+                            onSuccess = { showResult ->
+                                showMessage(
+                                    // Hadouken¹
+                                    "${showResult + storeResult} bytes were sent.",
+                                )
+                            },
+                            onFailure = { showMessage("❗${it.message ?: "Unknown error"} ❗") },
+                        )
+                    },
+                    onFailure = { showMessage("❗${it.message ?: "Unknown error"} ❗") },
+                )
+            }
         }
 
-        val slots = _uiState.value.slots
-
-        val configuration =
-            slots.getOrElse(slot) {
-                Timber.e("VM: Slot $slot is not one of our slots.")
-                null
-            } ?: return
-
-        val bitmap = configuration.bitmap
-        if (!bitmap.isBinary()) {
-            showMessage("Please create a binary image for page '${slot.name}'.")
-            return
-        }
-
-        if (!badgeManager.isConnected()) {
-            showMessage("Please connect a badge.")
-            return
-        }
-
-        viewModelScope.launch {
-            badgeManager.storePage(configuration.type.name, bitmap).fold(
-                onSuccess = { storeResult ->
-                    delay(300) // serial stuff
-                    badgeManager.showPage(configuration.type.name).fold(
-                        onSuccess = { showResult ->
-                            showMessage(
-                                // Hadouken¹
-                                "${showResult + storeResult} bytes were sent.",
-                            )
-                        },
-                        onFailure = { showMessage("❗${it.message ?: "Unknown error"} ❗") },
-                    )
-                },
-                onFailure = { showMessage("❗${it.message ?: "Unknown error"} ❗") },
-            )
-        }
-    }
-
-    /**
-     * Loop through given sponsor images.
-     *
-     * @param slot the slot to be configured.
-     */
-    fun customizeSponsorSlot(slot: ZeSlot) {
-        val slots = _uiState.value.slots
-        when (slot) {
-            is ZeSlot.FirstSponsor -> {
-                val slotsCopy =
-                    slots.copy(
-                        slot to
+        /**
+         * Loop through given sponsor images.
+         *
+         * @param slot the slot to be configured.
+         */
+        fun customizeSponsorSlot(slot: ZeSlot) {
+            val slots = _uiState.value.slots
+            when (slot) {
+                is ZeSlot.FirstSponsor -> {
+                    val slotsCopy =
+                        slots.copy(
+                            slot to
                                 ZeConfiguration.Picture(
                                     listOf(
                                         R.drawable.page_google,
@@ -188,353 +188,354 @@ constructor(
                                         .toBitmap()
                                         .pixelManipulation { w, h -> ditherFloydSteinberg(w, h) },
                                 ),
-                    )
-                _uiState.update {
-                    it.copy(slots = slotsCopy)
+                        )
+                    _uiState.update {
+                        it.copy(slots = slotsCopy)
+                    }
                 }
-            }
 
-            else -> {}
-        }
-    }
-
-    /**
-     * Configure the given slot
-     *
-     * @param slot the slot to be configured.
-     */
-    fun customizeSlot(slot: ZeSlot) {
-        _uiState.update {
-            it.copy(message = "")
-        }
-
-        // Do we need a template chooser first? Aka are we selecting a custom slot?
-        if (slot in listOf(ZeSlot.FirstCustom, ZeSlot.SecondCustom)) {
-            // yes, so let the user choose
-            viewModelScope.launch {
-                val apiKey = OPENAI_API_KEY.ifBlank { preferencesService.getOpenApiKey() }
-                val newCurrentTemplateChooser =
-                    ZeTemplateChooser(
-                        slot = slot,
-                        configurations = getTemplateConfigurations(apiKey),
-                    )
-                _uiState.update {
-                    it.copy(currentTemplateChooser = newCurrentTemplateChooser)
-                }
-            }
-        } else {
-            // no selection needed, check for name slot and ignore non configurable slots
-            val slots = _uiState.value.slots
-            val newCurrentSlotEditor =
-                ZeEditor(
-                    slot,
-                    slots[slot]!!,
-                )
-            newCurrentSlotEditor.let { currentSlotEditor ->
-                _uiState.update {
-                    it.copy(currentSlotEditor = currentSlotEditor)
-                }
+                else -> {}
             }
         }
-    }
 
-    /**
-     * User just selected the template to apply to a given slot, so open the according editor
-     *
-     * @param slot the slot to be changed, null if discarded
-     * @param configuration the configuration of the slot, null if discarded
-     */
-    fun templateSelected(
-        slot: ZeSlot?,
-        configuration: ZeConfiguration?,
-    ) {
-        var currentSlotEditor: ZeEditor? = null
-        if (slot != null && configuration != null) {
-            currentSlotEditor = ZeEditor(slot, configuration)
-        }
+        /**
+         * Configure the given slot
+         *
+         * @param slot the slot to be configured.
+         */
+        fun customizeSlot(slot: ZeSlot) {
+            _uiState.update {
+                it.copy(message = "")
+            }
 
-        _uiState.update {
-            if (currentSlotEditor != null) {
-                it.copy(
-                    currentTemplateChooser = null,
-                    currentSlotEditor = currentSlotEditor,
-                )
+            // Do we need a template chooser first? Aka are we selecting a custom slot?
+            if (slot in listOf(ZeSlot.FirstCustom, ZeSlot.SecondCustom)) {
+                // yes, so let the user choose
+                viewModelScope.launch {
+                    val apiKey = OPENAI_API_KEY.ifBlank { preferencesService.getOpenApiKey() }
+                    val newCurrentTemplateChooser =
+                        ZeTemplateChooser(
+                            slot = slot,
+                            configurations = getTemplateConfigurations(apiKey),
+                        )
+                    _uiState.update {
+                        it.copy(currentTemplateChooser = newCurrentTemplateChooser)
+                    }
+                }
             } else {
-                it.copy(currentTemplateChooser = null)
-            }
-        }
-    }
-
-    /**
-     * Editor closing, so the slot is configured successfully, unless parameters are null
-     *
-     * @param slot the slot configured.
-     * @param configuration the configuration of the slot.
-     */
-    fun slotConfigured(
-        slot: ZeSlot?,
-        configuration: ZeConfiguration?,
-    ) {
-        var newSlots: Map<ZeSlot, ZeConfiguration>? = null
-        if (slot != null && configuration != null) {
-            val slots = _uiState.value.slots
-            newSlots = slots.copy(slot to configuration)
-            saveSlotConfiguration(slot, configuration)
-        }
-        _uiState.update {
-            if (newSlots != null) {
-                it.copy(currentSlotEditor = null, slots = newSlots)
-            } else {
-                it.copy(currentSlotEditor = null)
-            }
-        }
-    }
-
-    /**
-     * In <em>Simulator Mode</em> this method will trigger display of the given slot
-     *
-     * @param slot the slot to be displayed.
-     */
-    fun simulatorButtonPressed(direction: ZeSimulatorButtonAction) {
-        val slotList = _uiState.value.slots.keys.toList()
-        val currentSlotIndex = slotList.indexOf(currentSimulatorSlot)
-
-        val slotToBePresented =
-            when (direction) {
-                ZeSimulatorButtonAction.FORWARD -> {
-                    val nextIndex =
-                        (currentSlotIndex + 1)
-                            .takeIf { it <= slotList.size - 1 }
-                            ?: currentSlotIndex
-
-                    slotList[nextIndex]
-                }
-
-                ZeSimulatorButtonAction.BACKWARD -> {
-                    val previousIndex =
-                        (currentSlotIndex - 1)
-                            .takeIf { it >= 0 }
-                            ?: currentSlotIndex
-
-                    slotList[previousIndex]
-                }
-
-                ZeSimulatorButtonAction.UP -> {
-                    Timber.d("Simulator Button Pressed", "Action not implemented yet.")
-                    // Returning the default one
-                    slotList[currentSlotIndex]
-                }
-
-                ZeSimulatorButtonAction.DOWN -> {
-                    Timber.d("Simulator Button Pressed", "Action not implemented yet.")
-                    // Returning the default one
-                    slotList[currentSlotIndex]
+                // no selection needed, check for name slot and ignore non configurable slots
+                val slots = _uiState.value.slots
+                val newCurrentSlotEditor =
+                    ZeEditor(
+                        slot,
+                        slots[slot]!!,
+                    )
+                newCurrentSlotEditor.let { currentSlotEditor ->
+                    _uiState.update {
+                        it.copy(currentSlotEditor = currentSlotEditor)
+                    }
                 }
             }
-
-        currentSimulatorSlot = slotToBePresented
-    }
-
-    /**
-     * Convert the given slot to a bitmap
-     *
-     * This could be used to display the slot in the UI, or to send it to the device internally.
-     *
-     * @param slot the slot to be converted
-     */
-    fun slotToBitmap(slot: ZeSlot?): Bitmap {
-        val slots = _uiState.value.slots
-        return slots[slot]?.bitmap ?: R.drawable.error.toBitmap().also {
-            Timber.d("Slot to Bitmap: Unavailable slot tried to fetch bitmap.")
         }
-    }
 
-    /**
-     * Reset the given slot to it's defaults when starting the app
-     *
-     * @param slot the slot to be defaulted
-     */
-    fun resetSlot(slot: ZeSlot) {
-        viewModelScope.launch {
-            // Removing all the saved data from the persistence
-            zeSlotRepository.removeSlotConfiguration(slot = slot)
-            // Getting the default value
-            val defaultSlotConfiguration = zeSlotRepository.getDefaultSlotConfiguration(slot = slot)
+        /**
+         * User just selected the template to apply to a given slot, so open the according editor
+         *
+         * @param slot the slot to be changed, null if discarded
+         * @param configuration the configuration of the slot, null if discarded
+         */
+        fun templateSelected(
+            slot: ZeSlot?,
+            configuration: ZeConfiguration?,
+        ) {
+            var currentSlotEditor: ZeEditor? = null
+            if (slot != null && configuration != null) {
+                currentSlotEditor = ZeEditor(slot, configuration)
+            }
 
             _uiState.update {
-                it.copy(
-                    message = "",
-                    slots = it.slots.copy(slot to defaultSlotConfiguration),
-                )
-            }
-        }
-    }
-
-    private suspend fun initialConfiguration(slot: ZeSlot): ZeConfiguration {
-        // try to get from the persistence, if not present, return the default
-        return zeSlotRepository.getSlotConfiguration(slot = slot)
-            ?: zeSlotRepository.getDefaultSlotConfiguration(slot = slot)
-    }
-
-    /**
-     * Save all slots to shared preferences and the badge.
-     */
-    fun saveAll() {
-        val slots = _uiState.value.slots
-        for ((slot, configuration) in slots) {
-            saveSlotConfiguration(slot, configuration)
-        }
-        storePages(slots)
-    }
-
-    private fun storePages(slots: Map<ZeSlot, ZeConfiguration>) {
-        if (!badgeManager.isConnected()) {
-            showMessage("Please connect a badge.")
-        } else {
-            viewModelScope.launch {
-                for ((slot, config) in slots) {
-                    val stored = badgeManager.storePage(slot.name, config.bitmap)
-                    if (stored.isFailure) {
-                        showMessage("Could not send page.")
-                    } else {
-                        showMessage("Page in slot '${slot.name}' send successfully.\n")
-                    }
+                if (currentSlotEditor != null) {
+                    it.copy(
+                        currentTemplateChooser = null,
+                        currentSlotEditor = currentSlotEditor,
+                    )
+                } else {
+                    it.copy(currentTemplateChooser = null)
                 }
             }
         }
-    }
 
-    /**
-     * Talks to the badge to get all stored pages from the badge
-     */
-    fun getStoredPages() {
-        if (!badgeManager.isConnected()) {
-            showMessage("Please connect a badge.")
-        } else {
-            viewModelScope.launch {
-                val stored = badgeManager.requestPagesStored()
-                if (stored.isSuccess) {
-                    val message = stored.getOrNull()
-                    if (message != null) {
-                        showMessage(message.replace(",", "\n"))
-                    }
+        /**
+         * Editor closing, so the slot is configured successfully, unless parameters are null
+         *
+         * @param slot the slot configured.
+         * @param configuration the configuration of the slot.
+         */
+        fun slotConfigured(
+            slot: ZeSlot?,
+            configuration: ZeConfiguration?,
+        ) {
+            var newSlots: Map<ZeSlot, ZeConfiguration>? = null
+            if (slot != null && configuration != null) {
+                val slots = _uiState.value.slots
+                newSlots = slots.copy(slot to configuration)
+                saveSlotConfiguration(slot, configuration)
+            }
+            _uiState.update {
+                if (newSlots != null) {
+                    it.copy(currentSlotEditor = null, slots = newSlots)
+                } else {
+                    it.copy(currentSlotEditor = null)
                 }
             }
         }
-    }
 
-    /**
-     * Talks to the badge to get the current active configuration
-     */
-    fun listConfiguration() {
-        if (!badgeManager.isConnected()) {
-            showMessage("Please connect a badge.")
-        } else {
+        /**
+         * In <em>Simulator Mode</em> this method will trigger display of the given slot
+         *
+         * @param slot the slot to be displayed.
+         */
+        fun simulatorButtonPressed(direction: ZeSimulatorButtonAction) {
+            val slotList = _uiState.value.slots.keys.toList()
+            val currentSlotIndex = slotList.indexOf(currentSimulatorSlot)
+
+            val slotToBePresented =
+                when (direction) {
+                    ZeSimulatorButtonAction.FORWARD -> {
+                        val nextIndex =
+                            (currentSlotIndex + 1)
+                                .takeIf { it <= slotList.size - 1 }
+                                ?: currentSlotIndex
+
+                        slotList[nextIndex]
+                    }
+
+                    ZeSimulatorButtonAction.BACKWARD -> {
+                        val previousIndex =
+                            (currentSlotIndex - 1)
+                                .takeIf { it >= 0 }
+                                ?: currentSlotIndex
+
+                        slotList[previousIndex]
+                    }
+
+                    ZeSimulatorButtonAction.UP -> {
+                        Timber.d("Simulator Button Pressed", "Action not implemented yet.")
+                        // Returning the default one
+                        slotList[currentSlotIndex]
+                    }
+
+                    ZeSimulatorButtonAction.DOWN -> {
+                        Timber.d("Simulator Button Pressed", "Action not implemented yet.")
+                        // Returning the default one
+                        slotList[currentSlotIndex]
+                    }
+                }
+
+            currentSimulatorSlot = slotToBePresented
+        }
+
+        /**
+         * Convert the given slot to a bitmap
+         *
+         * This could be used to display the slot in the UI, or to send it to the device internally.
+         *
+         * @param slot the slot to be converted
+         */
+        fun slotToBitmap(slot: ZeSlot?): Bitmap {
+            val slots = _uiState.value.slots
+            return slots[slot]?.bitmap ?: R.drawable.error.toBitmap().also {
+                Timber.d("Slot to Bitmap: Unavailable slot tried to fetch bitmap.")
+            }
+        }
+
+        /**
+         * Reset the given slot to it's defaults when starting the app
+         *
+         * @param slot the slot to be defaulted
+         */
+        fun resetSlot(slot: ZeSlot) {
             viewModelScope.launch {
-                val configResult = badgeManager.listConfiguration()
-                if (configResult.isSuccess) {
-                    val kv = configResult.getOrNull()
-                    if (kv != null) {
-                        showMessage(kv.toString())
-                        _uiState.update {
-                            it.copy(currentBadgeConfig = kv)
+                // Removing all the saved data from the persistence
+                zeSlotRepository.removeSlotConfiguration(slot = slot)
+                // Getting the default value
+                val defaultSlotConfiguration = zeSlotRepository.getDefaultSlotConfiguration(slot = slot)
+
+                _uiState.update {
+                    it.copy(
+                        message = "",
+                        slots = it.slots.copy(slot to defaultSlotConfiguration),
+                    )
+                }
+            }
+        }
+
+        private suspend fun initialConfiguration(slot: ZeSlot): ZeConfiguration {
+            // try to get from the persistence, if not present, return the default
+            return zeSlotRepository.getSlotConfiguration(slot = slot)
+                ?: zeSlotRepository.getDefaultSlotConfiguration(slot = slot)
+        }
+
+        /**
+         * Save all slots to shared preferences and the badge.
+         */
+        fun saveAll() {
+            val slots = _uiState.value.slots
+            for ((slot, configuration) in slots) {
+                saveSlotConfiguration(slot, configuration)
+            }
+            storePages(slots)
+        }
+
+        private fun storePages(slots: Map<ZeSlot, ZeConfiguration>) {
+            if (!badgeManager.isConnected()) {
+                showMessage("Please connect a badge.")
+            } else {
+                viewModelScope.launch {
+                    for ((slot, config) in slots) {
+                        val stored = badgeManager.storePage(slot.name, config.bitmap)
+                        if (stored.isFailure) {
+                            showMessage("Could not send page.")
+                        } else {
+                            showMessage("Page in slot '${slot.name}' send successfully.\n")
                         }
                     }
                 }
             }
         }
-    }
 
-    fun updateConfiguration(configuration: Map<String, Any?>) {
-        _uiState.update {
-            it.copy(currentBadgeConfig = null)
-        }
-
-        if (!badgeManager.isConnected()) {
-            showMessage("Please connect a badge.")
-        } else {
-            viewModelScope.launch {
-                badgeManager.updateConfiguration(configuration)
-                _uiState.update {
-                    it.copy(currentBadgeConfig = null)
+        /**
+         * Talks to the badge to get all stored pages from the badge
+         */
+        fun getStoredPages() {
+            if (!badgeManager.isConnected()) {
+                showMessage("Please connect a badge.")
+            } else {
+                viewModelScope.launch {
+                    val stored = badgeManager.requestPagesStored()
+                    if (stored.isSuccess) {
+                        val message = stored.getOrNull()
+                        if (message != null) {
+                            showMessage(message.replace(",", "\n"))
+                        }
+                    }
                 }
             }
         }
-    }
 
-    fun closeConfiguration() {
-        _uiState.update {
-            it.copy(currentBadgeConfig = null)
-        }
-    }
-
-    private fun Int.toBitmap(): Bitmap {
-        return imageProviderService.provideImageBitmap(this)
-    }
-
-    private fun saveSlotConfiguration(
-        slot: ZeSlot,
-        config: ZeConfiguration,
-    ) {
-        viewModelScope.launch(Dispatchers.IO) {
-            zeSlotRepository.saveSlotConfiguration(slot, config)
-        }
-    }
-
-    fun copyInfoToClipboard() {
-        clipboardService.copyToClipboard(_uiState.value.message)
-        showMessage("Copied")
-    }
-
-    fun setThemeSettings(themeSettings: Int) {
-        _uiState.update {
-            it.copy(themeSettings = themeSettings)
-        }
-
-        viewModelScope.launch(Dispatchers.IO) {
-            preferencesService.setThemeSettings(themeSettings)
-        }
-    }
-
-    fun setLocale(locale: String?) {
-        // Call this on the main thread as it may require Activity.restart()
-        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(locale))
-    }
-
-    /**
-     * Loads data from Datastore
-     */
-    private fun loadData() {
-        viewModelScope.launch(Dispatchers.IO) {
-            val slots = zeSlotRepository.getInitialSlots().associateWith {
-                initialConfiguration(it)
+        /**
+         * Talks to the badge to get the current active configuration
+         */
+        fun listConfiguration() {
+            if (!badgeManager.isConnected()) {
+                showMessage("Please connect a badge.")
+            } else {
+                viewModelScope.launch {
+                    val configResult = badgeManager.listConfiguration()
+                    if (configResult.isSuccess) {
+                        val kv = configResult.getOrNull()
+                        if (kv != null) {
+                            showMessage(kv.toString())
+                            _uiState.update {
+                                it.copy(currentBadgeConfig = kv)
+                            }
+                        }
+                    }
+                }
             }
+        }
 
-            val themeSettings = preferencesService.getThemeSettings()
-
+        fun updateConfiguration(configuration: Map<String, Any?>) {
             _uiState.update {
-                it.copy(slots = slots, themeSettings = themeSettings)
+                it.copy(currentBadgeConfig = null)
+            }
+
+            if (!badgeManager.isConnected()) {
+                showMessage("Please connect a badge.")
+            } else {
+                viewModelScope.launch {
+                    badgeManager.updateConfiguration(configuration)
+                    _uiState.update {
+                        it.copy(currentBadgeConfig = null)
+                    }
+                }
             }
         }
+
+        fun closeConfiguration() {
+            _uiState.update {
+                it.copy(currentBadgeConfig = null)
+            }
+        }
+
+        private fun Int.toBitmap(): Bitmap {
+            return imageProviderService.provideImageBitmap(this)
+        }
+
+        private fun saveSlotConfiguration(
+            slot: ZeSlot,
+            config: ZeConfiguration,
+        ) {
+            viewModelScope.launch(Dispatchers.IO) {
+                zeSlotRepository.saveSlotConfiguration(slot, config)
+            }
+        }
+
+        fun copyInfoToClipboard() {
+            clipboardService.copyToClipboard(_uiState.value.message)
+            showMessage("Copied")
+        }
+
+        fun setThemeSettings(themeSettings: Int) {
+            _uiState.update {
+                it.copy(themeSettings = themeSettings)
+            }
+
+            viewModelScope.launch(Dispatchers.IO) {
+                preferencesService.setThemeSettings(themeSettings)
+            }
+        }
+
+        fun setLocale(locale: String?) {
+            // Call this on the main thread as it may require Activity.restart()
+            AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(locale))
+        }
+
+        /**
+         * Loads data from Datastore
+         */
+        private fun loadData() {
+            viewModelScope.launch(Dispatchers.IO) {
+                val slots =
+                    zeSlotRepository.getInitialSlots().associateWith {
+                        initialConfiguration(it)
+                    }
+
+                val themeSettings = preferencesService.getThemeSettings()
+
+                _uiState.update {
+                    it.copy(slots = slots, themeSettings = themeSettings)
+                }
+            }
+        }
+
+        suspend fun fetchWeather(date: String) = weatherService.fetchWeather(date)
+
+        private fun getInitialUIState(): ZeBadgeUiState =
+            ZeBadgeUiState(
+                message = "",
+                messageProgress = 0.0f,
+                currentSlotEditor = null,
+                currentTemplateChooser = null,
+                slots = emptyMap(),
+                currentBadgeConfig = null,
+                themeSettings = null,
+            )
+
+        fun clearErrorState() {
+            _errorUiState.value = ZeBadgeErrorUiState.ClearError
+        }
     }
-
-    suspend fun fetchWeather(date: String) = weatherService.fetchWeather(date)
-
-    private fun getInitialUIState(): ZeBadgeUiState =
-        ZeBadgeUiState(
-            message = "",
-            messageProgress = 0.0f,
-            currentSlotEditor = null,
-            currentTemplateChooser = null,
-            slots = emptyMap(),
-            currentBadgeConfig = null,
-            themeSettings = null,
-        )
-
-    fun clearErrorState() {
-        _errorUiState.value = ZeBadgeErrorUiState.ClearError
-    }
-}
 
 data class ZeBadgeUiState(
     // message to be displayed to the user

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zevm/ZeBadgeViewModel.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zevm/ZeBadgeViewModel.kt
@@ -35,8 +35,6 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import timber.log.Timber
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 import javax.inject.Inject
 
 private const val MESSAGE_DISPLAY_DURATION = 3_000L
@@ -47,146 +45,139 @@ private const val MESSAGE_DISPLAY_UPDATES = 5
  */
 @HiltViewModel
 class ZeBadgeViewModel
-    @Inject
-    constructor(
-        private val imageProviderService: ZeImageProviderService,
-        private val badgeManager: ZeBadgeManager,
-        private val preferencesService: ZePreferencesService,
-        private val zeSlotRepository: ZeSlotRepository,
-        private val clipboardService: ZeClipboardService,
-        private val weatherService: ZeWeatherService,
-        private val getTemplateConfigurations: GetTemplateConfigurations,
-    ) : ViewModel() {
-        private val _uiState: MutableStateFlow<ZeBadgeUiState> = MutableStateFlow(getInitialUIState())
-        val uiState: StateFlow<ZeBadgeUiState> = _uiState.asStateFlow()
+@Inject
+constructor(
+    private val imageProviderService: ZeImageProviderService,
+    private val badgeManager: ZeBadgeManager,
+    private val preferencesService: ZePreferencesService,
+    private val zeSlotRepository: ZeSlotRepository,
+    private val clipboardService: ZeClipboardService,
+    private val weatherService: ZeWeatherService,
+    private val getTemplateConfigurations: GetTemplateConfigurations,
+) : ViewModel() {
+    private val _uiState: MutableStateFlow<ZeBadgeUiState> = MutableStateFlow(getInitialUIState())
+    val uiState: StateFlow<ZeBadgeUiState> = _uiState.asStateFlow()
 
-        private val _errorUiState: MutableStateFlow<ZeBadgeErrorUiState> = MutableStateFlow(ZeBadgeErrorUiState.Initial)
-        val errorUiState: StateFlow<ZeBadgeErrorUiState> = _errorUiState.asStateFlow()
+    private val _errorUiState: MutableStateFlow<ZeBadgeErrorUiState> = MutableStateFlow(ZeBadgeErrorUiState.Initial)
+    val errorUiState: StateFlow<ZeBadgeErrorUiState> = _errorUiState.asStateFlow()
 
-        // See if disappearing message is ongoing
-        private var hideMessageJob: Job? = null
-        private var messageProgressJob: Job? = null
-        private val initialSlots =
-            listOf(
-                ZeSlot.Name,
-                ZeSlot.FirstSponsor,
-                ZeSlot.Camera,
-                ZeSlot.Add,
-            )
+    // See if disappearing message is ongoing
+    private var hideMessageJob: Job? = null
+    private var messageProgressJob: Job? = null
 
-        // This needed to be created to avoid refactoring all the comoposables
-        // We should avoid passing down the VM and pass only the state
+    // This needed to be created to avoid refactoring all the comoposables
+    // We should avoid passing down the VM and pass only the state
 
-        // Represents the current slot showing on the simulator
-        var currentSimulatorSlot by mutableStateOf(initialSlots.first())
-            private set
+    // Represents the current slot showing on the simulator
+    var currentSimulatorSlot by mutableStateOf(zeSlotRepository.getInitialSlots().first())
+        private set
 
-        init {
-            loadData()
+    init {
+        loadData()
+    }
+
+    fun showMessage(
+        message: String,
+        showAsError: Boolean = false,
+        duration: Long = MESSAGE_DISPLAY_DURATION,
+    ) {
+        _uiState.update {
+            it.copy(message = it.message + message)
         }
 
-        fun showMessage(
-            message: String,
-            showAsError: Boolean = false,
-            duration: Long = MESSAGE_DISPLAY_DURATION,
-        ) {
-            _uiState.update {
-                it.copy(message = it.message + message)
-            }
+        scheduleMessageDisappearance(duration)
 
-            scheduleMessageDisappearance(duration)
-
-            if (showAsError) {
-                emitSnackBarAction(message = message)
-            }
+        if (showAsError) {
+            emitSnackBarAction(message = message)
         }
+    }
 
-        private fun emitSnackBarAction(message: String) {
-            _errorUiState.value = ZeBadgeErrorUiState.ShowError(message)
-        }
+    private fun emitSnackBarAction(message: String) {
+        _errorUiState.value = ZeBadgeErrorUiState.ShowError(message)
+    }
 
-        private fun scheduleMessageDisappearance(duration: Long = MESSAGE_DISPLAY_DURATION) {
-            hideMessageJob?.cancel()
-            hideMessageJob =
-                viewModelScope.launch {
-                    delay(duration)
-                    _uiState.update {
-                        it.copy(message = "")
-                    }
-                }
-
-            messageProgressJob?.cancel()
-            messageProgressJob =
-                viewModelScope.launch {
-                    for (progress in 0 until MESSAGE_DISPLAY_UPDATES) {
-                        _uiState.update {
-                            it.copy(messageProgress = 1.0f - progress / MESSAGE_DISPLAY_UPDATES.toFloat())
-                        }
-                        delay(duration / MESSAGE_DISPLAY_UPDATES)
-                    }
-                }
-        }
-
-        /**
-         * Call this method to send a given slot to the badge device.
-         *
-         * @param slot to be sent.
-         */
-        fun sendPageToBadgeAndDisplay(slot: ZeSlot) {
-            _uiState.update {
-                it.copy(message = "")
-            }
-
-            val slots = _uiState.value.slots
-
-            val configuration =
-                slots.getOrElse(slot) {
-                    Timber.e("VM: Slot $slot is not one of our slots.")
-                    null
-                } ?: return
-
-            val bitmap = configuration.bitmap
-            if (!bitmap.isBinary()) {
-                showMessage("Please create a binary image for page '${slot.name}'.")
-                return
-            }
-
-            if (!badgeManager.isConnected()) {
-                showMessage("Please connect a badge.")
-                return
-            }
-
+    private fun scheduleMessageDisappearance(duration: Long = MESSAGE_DISPLAY_DURATION) {
+        hideMessageJob?.cancel()
+        hideMessageJob =
             viewModelScope.launch {
-                badgeManager.storePage(configuration.type.name, bitmap).fold(
-                    onSuccess = { storeResult ->
-                        delay(300) // serial stuff
-                        badgeManager.showPage(configuration.type.name).fold(
-                            onSuccess = { showResult ->
-                                showMessage(
-                                    // Hadouken¹
-                                    "${showResult + storeResult} bytes were sent.",
-                                )
-                            },
-                            onFailure = { showMessage("❗${it.message ?: "Unknown error"} ❗") },
-                        )
-                    },
-                    onFailure = { showMessage("❗${it.message ?: "Unknown error"} ❗") },
-                )
+                delay(duration)
+                _uiState.update {
+                    it.copy(message = "")
+                }
             }
+
+        messageProgressJob?.cancel()
+        messageProgressJob =
+            viewModelScope.launch {
+                for (progress in 0 until MESSAGE_DISPLAY_UPDATES) {
+                    _uiState.update {
+                        it.copy(messageProgress = 1.0f - progress / MESSAGE_DISPLAY_UPDATES.toFloat())
+                    }
+                    delay(duration / MESSAGE_DISPLAY_UPDATES)
+                }
+            }
+    }
+
+    /**
+     * Call this method to send a given slot to the badge device.
+     *
+     * @param slot to be sent.
+     */
+    fun sendPageToBadgeAndDisplay(slot: ZeSlot) {
+        _uiState.update {
+            it.copy(message = "")
         }
 
-        /**
-         * Loop through given sponsor images.
-         *
-         * @param slot the slot to be configured.
-         */
-        fun customizeSponsorSlot(slot: ZeSlot) {
-            val slots = _uiState.value.slots
-            when (slot) {
-                is ZeSlot.FirstSponsor -> {
-                    val slotsCopy =
-                        slots.copy(
-                            slot to
+        val slots = _uiState.value.slots
+
+        val configuration =
+            slots.getOrElse(slot) {
+                Timber.e("VM: Slot $slot is not one of our slots.")
+                null
+            } ?: return
+
+        val bitmap = configuration.bitmap
+        if (!bitmap.isBinary()) {
+            showMessage("Please create a binary image for page '${slot.name}'.")
+            return
+        }
+
+        if (!badgeManager.isConnected()) {
+            showMessage("Please connect a badge.")
+            return
+        }
+
+        viewModelScope.launch {
+            badgeManager.storePage(configuration.type.name, bitmap).fold(
+                onSuccess = { storeResult ->
+                    delay(300) // serial stuff
+                    badgeManager.showPage(configuration.type.name).fold(
+                        onSuccess = { showResult ->
+                            showMessage(
+                                // Hadouken¹
+                                "${showResult + storeResult} bytes were sent.",
+                            )
+                        },
+                        onFailure = { showMessage("❗${it.message ?: "Unknown error"} ❗") },
+                    )
+                },
+                onFailure = { showMessage("❗${it.message ?: "Unknown error"} ❗") },
+            )
+        }
+    }
+
+    /**
+     * Loop through given sponsor images.
+     *
+     * @param slot the slot to be configured.
+     */
+    fun customizeSponsorSlot(slot: ZeSlot) {
+        val slots = _uiState.value.slots
+        when (slot) {
+            is ZeSlot.FirstSponsor -> {
+                val slotsCopy =
+                    slots.copy(
+                        slot to
                                 ZeConfiguration.Picture(
                                     listOf(
                                         R.drawable.page_google,
@@ -197,408 +188,353 @@ class ZeBadgeViewModel
                                         .toBitmap()
                                         .pixelManipulation { w, h -> ditherFloydSteinberg(w, h) },
                                 ),
-                        )
-                    _uiState.update {
-                        it.copy(slots = slotsCopy)
-                    }
-                }
-
-                else -> {}
-            }
-        }
-
-        /**
-         * Configure the given slot
-         *
-         * @param slot the slot to be configured.
-         */
-        fun customizeSlot(slot: ZeSlot) {
-            _uiState.update {
-                it.copy(message = "")
-            }
-
-            // Do we need a template chooser first? Aka are we selecting a custom slot?
-            if (slot in listOf(ZeSlot.FirstCustom, ZeSlot.SecondCustom)) {
-                // yes, so let the user choose
-                viewModelScope.launch {
-                    val apiKey = OPENAI_API_KEY.ifBlank { preferencesService.getOpenApiKey() }
-                    val newCurrentTemplateChooser =
-                        ZeTemplateChooser(
-                            slot = slot,
-                            configurations = getTemplateConfigurations(apiKey),
-                        )
-                    _uiState.update {
-                        it.copy(currentTemplateChooser = newCurrentTemplateChooser)
-                    }
-                }
-            } else {
-                // no selection needed, check for name slot and ignore non configurable slots
-                val slots = _uiState.value.slots
-                val newCurrentSlotEditor =
-                    ZeEditor(
-                        slot,
-                        slots[slot]!!,
                     )
-                newCurrentSlotEditor.let { currentSlotEditor ->
-                    _uiState.update {
-                        it.copy(currentSlotEditor = currentSlotEditor)
-                    }
-                }
-            }
-        }
-
-        /**
-         * User just selected the template to apply to a given slot, so open the according editor
-         *
-         * @param slot the slot to be changed, null if discarded
-         * @param configuration the configuration of the slot, null if discarded
-         */
-        fun templateSelected(
-            slot: ZeSlot?,
-            configuration: ZeConfiguration?,
-        ) {
-            var currentSlotEditor: ZeEditor? = null
-            if (slot != null && configuration != null) {
-                currentSlotEditor = ZeEditor(slot, configuration)
-            }
-
-            _uiState.update {
-                if (currentSlotEditor != null) {
-                    it.copy(
-                        currentTemplateChooser = null,
-                        currentSlotEditor = currentSlotEditor,
-                    )
-                } else {
-                    it.copy(currentTemplateChooser = null)
-                }
-            }
-        }
-
-        /**
-         * Editor closing, so the slot is configured successfully, unless parameters are null
-         *
-         * @param slot the slot configured.
-         * @param configuration the configuration of the slot.
-         */
-        fun slotConfigured(
-            slot: ZeSlot?,
-            configuration: ZeConfiguration?,
-        ) {
-            var newSlots: Map<ZeSlot, ZeConfiguration>? = null
-            if (slot != null && configuration != null) {
-                val slots = _uiState.value.slots
-                newSlots = slots.copy(slot to configuration)
-                saveSlotConfiguration(slot, configuration)
-            }
-            _uiState.update {
-                if (newSlots != null) {
-                    it.copy(currentSlotEditor = null, slots = newSlots)
-                } else {
-                    it.copy(currentSlotEditor = null)
-                }
-            }
-        }
-
-        /**
-         * In <em>Simulator Mode</em> this method will trigger display of the given slot
-         *
-         * @param slot the slot to be displayed.
-         */
-        fun simulatorButtonPressed(direction: ZeSimulatorButtonAction) {
-            val slotList = _uiState.value.slots.keys.toList()
-            val currentSlotIndex = slotList.indexOf(currentSimulatorSlot)
-
-            val slotToBePresented =
-                when (direction) {
-                    ZeSimulatorButtonAction.FORWARD -> {
-                        val nextIndex =
-                            (currentSlotIndex + 1)
-                                .takeIf { it <= slotList.size - 1 }
-                                ?: currentSlotIndex
-
-                        slotList[nextIndex]
-                    }
-
-                    ZeSimulatorButtonAction.BACKWARD -> {
-                        val previousIndex =
-                            (currentSlotIndex - 1)
-                                .takeIf { it >= 0 }
-                                ?: currentSlotIndex
-
-                        slotList[previousIndex]
-                    }
-
-                    ZeSimulatorButtonAction.UP -> {
-                        Timber.d("Simulator Button Pressed", "Action not implemented yet.")
-                        // Returning the default one
-                        slotList[currentSlotIndex]
-                    }
-
-                    ZeSimulatorButtonAction.DOWN -> {
-                        Timber.d("Simulator Button Pressed", "Action not implemented yet.")
-                        // Returning the default one
-                        slotList[currentSlotIndex]
-                    }
-                }
-
-            currentSimulatorSlot = slotToBePresented
-        }
-
-        /**
-         * Convert the given slot to a bitmap
-         *
-         * This could be used to display the slot in the UI, or to send it to the device internally.
-         *
-         * @param slot the slot to be converted
-         */
-        fun slotToBitmap(slot: ZeSlot?): Bitmap {
-            val slots = _uiState.value.slots
-            return slots[slot]?.bitmap ?: R.drawable.error.toBitmap().also {
-                Timber.d("Slot to Bitmap: Unavailable slot tried to fetch bitmap.")
-            }
-        }
-
-        /**
-         * Reset the given slot to it's defaults when starting the app
-         *
-         * @param slot the slot to be defaulted
-         */
-        fun resetSlot(slot: ZeSlot) {
-            viewModelScope.launch {
                 _uiState.update {
-                    it.copy(
-                        message = "",
-                        slots = it.slots.copy(slot to initialConfiguration(slot)),
-                    )
-                }
-            }
-        }
-
-        private suspend fun initialConfiguration(slot: ZeSlot): ZeConfiguration {
-            if (preferencesService.isSlotConfigured(slot)) {
-                val configuration = zeSlotRepository.getSlotConfiguration(slot)
-                if (configuration != null) {
-                    return configuration
+                    it.copy(slots = slotsCopy)
                 }
             }
 
-            return when (slot) {
-                is ZeSlot.Name ->
-                    ZeConfiguration.Name(
-                        null,
-                        null,
-                        imageProviderService.getInitialNameBitmap(),
-                    )
-
-                is ZeSlot.FirstSponsor -> ZeConfiguration.Picture(R.drawable.page_google.toBitmap())
-                is ZeSlot.FirstCustom -> ZeConfiguration.Picture(R.drawable.soon.toBitmap())
-                is ZeSlot.SecondCustom -> ZeConfiguration.Picture(R.drawable.soon.toBitmap())
-                ZeSlot.QRCode ->
-                    ZeConfiguration.QRCode(
-                        title = "",
-                        text = "",
-                        url = "",
-                        isVcard = false,
-                        phone = "",
-                        email = "",
-                        bitmap = R.drawable.qrpage_preview.toBitmap(),
-                    )
-
-                ZeSlot.Weather ->
-                    ZeConfiguration.Weather(
-                        LocalDateTime.now().format(DateTimeFormatter.ISO_LOCAL_DATE),
-                        "22C",
-                        R.drawable.soon.toBitmap(),
-                    )
-
-                is ZeSlot.Quote ->
-                    ZeConfiguration.Quote(
-                        "Test",
-                        "Author",
-                        R.drawable.page_quote_sample.toBitmap(),
-                    )
-
-                ZeSlot.BarCode ->
-                    ZeConfiguration.BarCode(
-                        "Your title for barcode",
-                        "",
-                        R.drawable.soon.toBitmap(),
-                    )
-
-                ZeSlot.Add ->
-                    ZeConfiguration.Name(
-                        null,
-                        null,
-                        imageProviderService.provideImageBitmap(R.drawable.add),
-                    )
-
-                ZeSlot.Camera ->
-                    ZeConfiguration.Camera(
-                        imageProviderService.provideImageBitmap(R.drawable.soon),
-                    )
-            }
-        }
-
-        /**
-         * Save all slots to shared preferences and the badge.
-         */
-        fun saveAll() {
-            val slots = _uiState.value.slots
-            for ((slot, configuration) in slots) {
-                saveSlotConfiguration(slot, configuration)
-            }
-            storePages(slots)
-        }
-
-        private fun storePages(slots: Map<ZeSlot, ZeConfiguration>) {
-            if (!badgeManager.isConnected()) {
-                showMessage("Please connect a badge.")
-            } else {
-                viewModelScope.launch {
-                    for ((slot, config) in slots) {
-                        val stored = badgeManager.storePage(slot.name, config.bitmap)
-                        if (stored.isFailure) {
-                            showMessage("Could not send page.")
-                        } else {
-                            showMessage("Page in slot '${slot.name}' send successfully.\n")
-                        }
-                    }
-                }
-            }
-        }
-
-        /**
-         * Talks to the badge to get all stored pages from the badge
-         */
-        fun getStoredPages() {
-            if (!badgeManager.isConnected()) {
-                showMessage("Please connect a badge.")
-            } else {
-                viewModelScope.launch {
-                    val stored = badgeManager.requestPagesStored()
-                    if (stored.isSuccess) {
-                        val message = stored.getOrNull()
-                        if (message != null) {
-                            showMessage(message.replace(",", "\n"))
-                        }
-                    }
-                }
-            }
-        }
-
-        /**
-         * Talks to the badge to get the current active configuration
-         */
-        fun listConfiguration() {
-            if (!badgeManager.isConnected()) {
-                showMessage("Please connect a badge.")
-            } else {
-                viewModelScope.launch {
-                    val configResult = badgeManager.listConfiguration()
-                    if (configResult.isSuccess) {
-                        val kv = configResult.getOrNull()
-                        if (kv != null) {
-                            showMessage(kv.toString())
-                            _uiState.update {
-                                it.copy(currentBadgeConfig = kv)
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        fun updateConfiguration(configuration: Map<String, Any?>) {
-            _uiState.update {
-                it.copy(currentBadgeConfig = null)
-            }
-
-            if (!badgeManager.isConnected()) {
-                showMessage("Please connect a badge.")
-            } else {
-                viewModelScope.launch {
-                    badgeManager.updateConfiguration(configuration)
-                    _uiState.update {
-                        it.copy(currentBadgeConfig = null)
-                    }
-                }
-            }
-        }
-
-        fun closeConfiguration() {
-            _uiState.update {
-                it.copy(currentBadgeConfig = null)
-            }
-        }
-
-        private fun Int.toBitmap(): Bitmap {
-            return imageProviderService.provideImageBitmap(this)
-        }
-
-        private fun saveSlotConfiguration(
-            slot: ZeSlot,
-            config: ZeConfiguration,
-        ) {
-            viewModelScope.launch(Dispatchers.IO) {
-                zeSlotRepository.saveSlotConfiguration(slot, config)
-            }
-        }
-
-        fun copyInfoToClipboard() {
-            clipboardService.copyToClipboard(_uiState.value.message)
-            showMessage("Copied")
-        }
-
-        fun setThemeSettings(themeSettings: Int) {
-            _uiState.update {
-                it.copy(themeSettings = themeSettings)
-            }
-
-            viewModelScope.launch(Dispatchers.IO) {
-                preferencesService.setThemeSettings(themeSettings)
-            }
-        }
-
-        fun setLocale(locale: String?) {
-            // Call this on the main thread as it may require Activity.restart()
-            AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(locale))
-        }
-
-        /**
-         * Loads data from Datastore
-         */
-        private fun loadData() {
-            viewModelScope.launch(Dispatchers.IO) {
-                val slots =
-                    initialSlots.associateWith {
-                        initialConfiguration(it)
-                    }
-
-                val themeSettings = preferencesService.getThemeSettings()
-
-                _uiState.update {
-                    it.copy(slots = slots, themeSettings = themeSettings)
-                }
-            }
-        }
-
-        suspend fun fetchWeather(date: String) = weatherService.fetchWeather(date)
-
-        private fun getInitialUIState(): ZeBadgeUiState =
-            ZeBadgeUiState(
-                message = "",
-                messageProgress = 0.0f,
-                currentSlotEditor = null,
-                currentTemplateChooser = null,
-                slots = emptyMap(),
-                currentBadgeConfig = null,
-                themeSettings = null,
-            )
-
-        fun clearErrorState() {
-            _errorUiState.value = ZeBadgeErrorUiState.ClearError
+            else -> {}
         }
     }
+
+    /**
+     * Configure the given slot
+     *
+     * @param slot the slot to be configured.
+     */
+    fun customizeSlot(slot: ZeSlot) {
+        _uiState.update {
+            it.copy(message = "")
+        }
+
+        // Do we need a template chooser first? Aka are we selecting a custom slot?
+        if (slot in listOf(ZeSlot.FirstCustom, ZeSlot.SecondCustom)) {
+            // yes, so let the user choose
+            viewModelScope.launch {
+                val apiKey = OPENAI_API_KEY.ifBlank { preferencesService.getOpenApiKey() }
+                val newCurrentTemplateChooser =
+                    ZeTemplateChooser(
+                        slot = slot,
+                        configurations = getTemplateConfigurations(apiKey),
+                    )
+                _uiState.update {
+                    it.copy(currentTemplateChooser = newCurrentTemplateChooser)
+                }
+            }
+        } else {
+            // no selection needed, check for name slot and ignore non configurable slots
+            val slots = _uiState.value.slots
+            val newCurrentSlotEditor =
+                ZeEditor(
+                    slot,
+                    slots[slot]!!,
+                )
+            newCurrentSlotEditor.let { currentSlotEditor ->
+                _uiState.update {
+                    it.copy(currentSlotEditor = currentSlotEditor)
+                }
+            }
+        }
+    }
+
+    /**
+     * User just selected the template to apply to a given slot, so open the according editor
+     *
+     * @param slot the slot to be changed, null if discarded
+     * @param configuration the configuration of the slot, null if discarded
+     */
+    fun templateSelected(
+        slot: ZeSlot?,
+        configuration: ZeConfiguration?,
+    ) {
+        var currentSlotEditor: ZeEditor? = null
+        if (slot != null && configuration != null) {
+            currentSlotEditor = ZeEditor(slot, configuration)
+        }
+
+        _uiState.update {
+            if (currentSlotEditor != null) {
+                it.copy(
+                    currentTemplateChooser = null,
+                    currentSlotEditor = currentSlotEditor,
+                )
+            } else {
+                it.copy(currentTemplateChooser = null)
+            }
+        }
+    }
+
+    /**
+     * Editor closing, so the slot is configured successfully, unless parameters are null
+     *
+     * @param slot the slot configured.
+     * @param configuration the configuration of the slot.
+     */
+    fun slotConfigured(
+        slot: ZeSlot?,
+        configuration: ZeConfiguration?,
+    ) {
+        var newSlots: Map<ZeSlot, ZeConfiguration>? = null
+        if (slot != null && configuration != null) {
+            val slots = _uiState.value.slots
+            newSlots = slots.copy(slot to configuration)
+            saveSlotConfiguration(slot, configuration)
+        }
+        _uiState.update {
+            if (newSlots != null) {
+                it.copy(currentSlotEditor = null, slots = newSlots)
+            } else {
+                it.copy(currentSlotEditor = null)
+            }
+        }
+    }
+
+    /**
+     * In <em>Simulator Mode</em> this method will trigger display of the given slot
+     *
+     * @param slot the slot to be displayed.
+     */
+    fun simulatorButtonPressed(direction: ZeSimulatorButtonAction) {
+        val slotList = _uiState.value.slots.keys.toList()
+        val currentSlotIndex = slotList.indexOf(currentSimulatorSlot)
+
+        val slotToBePresented =
+            when (direction) {
+                ZeSimulatorButtonAction.FORWARD -> {
+                    val nextIndex =
+                        (currentSlotIndex + 1)
+                            .takeIf { it <= slotList.size - 1 }
+                            ?: currentSlotIndex
+
+                    slotList[nextIndex]
+                }
+
+                ZeSimulatorButtonAction.BACKWARD -> {
+                    val previousIndex =
+                        (currentSlotIndex - 1)
+                            .takeIf { it >= 0 }
+                            ?: currentSlotIndex
+
+                    slotList[previousIndex]
+                }
+
+                ZeSimulatorButtonAction.UP -> {
+                    Timber.d("Simulator Button Pressed", "Action not implemented yet.")
+                    // Returning the default one
+                    slotList[currentSlotIndex]
+                }
+
+                ZeSimulatorButtonAction.DOWN -> {
+                    Timber.d("Simulator Button Pressed", "Action not implemented yet.")
+                    // Returning the default one
+                    slotList[currentSlotIndex]
+                }
+            }
+
+        currentSimulatorSlot = slotToBePresented
+    }
+
+    /**
+     * Convert the given slot to a bitmap
+     *
+     * This could be used to display the slot in the UI, or to send it to the device internally.
+     *
+     * @param slot the slot to be converted
+     */
+    fun slotToBitmap(slot: ZeSlot?): Bitmap {
+        val slots = _uiState.value.slots
+        return slots[slot]?.bitmap ?: R.drawable.error.toBitmap().also {
+            Timber.d("Slot to Bitmap: Unavailable slot tried to fetch bitmap.")
+        }
+    }
+
+    /**
+     * Reset the given slot to it's defaults when starting the app
+     *
+     * @param slot the slot to be defaulted
+     */
+    fun resetSlot(slot: ZeSlot) {
+        viewModelScope.launch {
+            // Removing all the saved data from the persistence
+            zeSlotRepository.removeSlotConfiguration(slot = slot)
+            // Getting the default value
+            val defaultSlotConfiguration = zeSlotRepository.getDefaultSlotConfiguration(slot = slot)
+
+            _uiState.update {
+                it.copy(
+                    message = "",
+                    slots = it.slots.copy(slot to defaultSlotConfiguration),
+                )
+            }
+        }
+    }
+
+    private suspend fun initialConfiguration(slot: ZeSlot): ZeConfiguration {
+        // try to get from the persistence, if not present, return the default
+        return zeSlotRepository.getSlotConfiguration(slot = slot)
+            ?: zeSlotRepository.getDefaultSlotConfiguration(slot = slot)
+    }
+
+    /**
+     * Save all slots to shared preferences and the badge.
+     */
+    fun saveAll() {
+        val slots = _uiState.value.slots
+        for ((slot, configuration) in slots) {
+            saveSlotConfiguration(slot, configuration)
+        }
+        storePages(slots)
+    }
+
+    private fun storePages(slots: Map<ZeSlot, ZeConfiguration>) {
+        if (!badgeManager.isConnected()) {
+            showMessage("Please connect a badge.")
+        } else {
+            viewModelScope.launch {
+                for ((slot, config) in slots) {
+                    val stored = badgeManager.storePage(slot.name, config.bitmap)
+                    if (stored.isFailure) {
+                        showMessage("Could not send page.")
+                    } else {
+                        showMessage("Page in slot '${slot.name}' send successfully.\n")
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Talks to the badge to get all stored pages from the badge
+     */
+    fun getStoredPages() {
+        if (!badgeManager.isConnected()) {
+            showMessage("Please connect a badge.")
+        } else {
+            viewModelScope.launch {
+                val stored = badgeManager.requestPagesStored()
+                if (stored.isSuccess) {
+                    val message = stored.getOrNull()
+                    if (message != null) {
+                        showMessage(message.replace(",", "\n"))
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * Talks to the badge to get the current active configuration
+     */
+    fun listConfiguration() {
+        if (!badgeManager.isConnected()) {
+            showMessage("Please connect a badge.")
+        } else {
+            viewModelScope.launch {
+                val configResult = badgeManager.listConfiguration()
+                if (configResult.isSuccess) {
+                    val kv = configResult.getOrNull()
+                    if (kv != null) {
+                        showMessage(kv.toString())
+                        _uiState.update {
+                            it.copy(currentBadgeConfig = kv)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    fun updateConfiguration(configuration: Map<String, Any?>) {
+        _uiState.update {
+            it.copy(currentBadgeConfig = null)
+        }
+
+        if (!badgeManager.isConnected()) {
+            showMessage("Please connect a badge.")
+        } else {
+            viewModelScope.launch {
+                badgeManager.updateConfiguration(configuration)
+                _uiState.update {
+                    it.copy(currentBadgeConfig = null)
+                }
+            }
+        }
+    }
+
+    fun closeConfiguration() {
+        _uiState.update {
+            it.copy(currentBadgeConfig = null)
+        }
+    }
+
+    private fun Int.toBitmap(): Bitmap {
+        return imageProviderService.provideImageBitmap(this)
+    }
+
+    private fun saveSlotConfiguration(
+        slot: ZeSlot,
+        config: ZeConfiguration,
+    ) {
+        viewModelScope.launch(Dispatchers.IO) {
+            zeSlotRepository.saveSlotConfiguration(slot, config)
+        }
+    }
+
+    fun copyInfoToClipboard() {
+        clipboardService.copyToClipboard(_uiState.value.message)
+        showMessage("Copied")
+    }
+
+    fun setThemeSettings(themeSettings: Int) {
+        _uiState.update {
+            it.copy(themeSettings = themeSettings)
+        }
+
+        viewModelScope.launch(Dispatchers.IO) {
+            preferencesService.setThemeSettings(themeSettings)
+        }
+    }
+
+    fun setLocale(locale: String?) {
+        // Call this on the main thread as it may require Activity.restart()
+        AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(locale))
+    }
+
+    /**
+     * Loads data from Datastore
+     */
+    private fun loadData() {
+        viewModelScope.launch(Dispatchers.IO) {
+            val slots = zeSlotRepository.getInitialSlots().associateWith {
+                initialConfiguration(it)
+            }
+
+            val themeSettings = preferencesService.getThemeSettings()
+
+            _uiState.update {
+                it.copy(slots = slots, themeSettings = themeSettings)
+            }
+        }
+    }
+
+    suspend fun fetchWeather(date: String) = weatherService.fetchWeather(date)
+
+    private fun getInitialUIState(): ZeBadgeUiState =
+        ZeBadgeUiState(
+            message = "",
+            messageProgress = 0.0f,
+            currentSlotEditor = null,
+            currentTemplateChooser = null,
+            slots = emptyMap(),
+            currentBadgeConfig = null,
+            themeSettings = null,
+        )
+
+    fun clearErrorState() {
+        _errorUiState.value = ZeBadgeErrorUiState.ClearError
+    }
+}
 
 data class ZeBadgeUiState(
     // message to be displayed to the user

--- a/zeapp/android/src/main/java/de/berlindroid/zeapp/zevm/ZeBadgeViewModel.kt
+++ b/zeapp/android/src/main/java/de/berlindroid/zeapp/zevm/ZeBadgeViewModel.kt
@@ -17,6 +17,7 @@ import de.berlindroid.zeapp.zemodels.ZeConfiguration
 import de.berlindroid.zeapp.zemodels.ZeEditor
 import de.berlindroid.zeapp.zemodels.ZeSlot
 import de.berlindroid.zeapp.zemodels.ZeTemplateChooser
+import de.berlindroid.zeapp.zerepositories.ZeSlotRepository
 import de.berlindroid.zeapp.zeservices.ZeBadgeManager
 import de.berlindroid.zeapp.zeservices.ZeClipboardService
 import de.berlindroid.zeapp.zeservices.ZeImageProviderService
@@ -51,6 +52,7 @@ class ZeBadgeViewModel
         private val imageProviderService: ZeImageProviderService,
         private val badgeManager: ZeBadgeManager,
         private val preferencesService: ZePreferencesService,
+        private val zeSlotRepository: ZeSlotRepository,
         private val clipboardService: ZeClipboardService,
         private val weatherService: ZeWeatherService,
         private val getTemplateConfigurations: GetTemplateConfigurations,
@@ -374,7 +376,7 @@ class ZeBadgeViewModel
 
         private suspend fun initialConfiguration(slot: ZeSlot): ZeConfiguration {
             if (preferencesService.isSlotConfigured(slot)) {
-                val configuration = preferencesService.getSlotConfiguration(slot)
+                val configuration = zeSlotRepository.getSlotConfiguration(slot)
                 if (configuration != null) {
                     return configuration
                 }
@@ -538,7 +540,7 @@ class ZeBadgeViewModel
             config: ZeConfiguration,
         ) {
             viewModelScope.launch(Dispatchers.IO) {
-                preferencesService.saveSlotConfiguration(slot, config)
+                zeSlotRepository.saveSlotConfiguration(slot, config)
             }
         }
 


### PR DESCRIPTION
## Summary

<!--Provide a summary of this Pull Request. -->
- Extracting the logic from `ZePersistence`, which handled theme, open api and zeslot rules to a `ZeSlotRepository`;
- With this approach we can use this repository across screens and possibly detach current features to use their own VM (such as the simulator screen);
- Also enables (if needed) to change how the data is retrieved, we can change it to a flow and shift to observable pattern for example;
- As a bonus, this fixes Fixes #395, since it enables us to add and remove previously saved configurations.

## How It Was Tested

<!-- Explain how you tested this change before merging. -->

## Screenshot/Gif

<!-- If applicable, show off the user facing changes. -->
| Reset fix | Overall behavior |
| ---- | ----- |
| <video src=https://github.com/user-attachments/assets/98f28b3a-3fc1-44f9-b2c3-c7991f8fe905 /> | <video src=https://github.com/user-attachments/assets/cc71cf9d-cce4-4efa-8cb9-7b16e867d514 /> |


<details>

<summary>Screenshot Name</summary>

<!-- file here -->

</details>